### PR TITLE
ci: run full test suite with coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,50 @@ jobs:
         run: cargo test --workspace --all-features
 
   # ─────────────────────────────────────────────────────────────────────────
-  # Job 4: Basic examples (fast, per-example feedback)
+  # Job 4: Coverage
+  # ─────────────────────────────────────────────────────────────────────────
+  coverage:
+    name: Coverage (Tarpaulin)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+          targets: wasm32-unknown-unknown
+
+      - name: Cache Cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-coverage-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-coverage-
+
+      - name: Install cargo-tarpaulin
+        run: cargo install cargo-tarpaulin --locked
+
+      - name: Generate coverage report
+        run: cargo tarpaulin --workspace --all-features --out xml --output-dir ./coverage --timeout 300
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cobertura-xml
+          path: ./coverage/cobertura.xml
+
+      - name: Upload coverage to Codecov (optional)
+        uses: codecov/codecov-action@v4
+        with:
+          files: ./coverage/cobertura.xml
+          fail_ci_if_error: false
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # Job 5: Basic examples (fast, per-example feedback)
   # ─────────────────────────────────────────────────────────────────────────
   basic-examples:
     name: Basic Examples CI


### PR DESCRIPTION
Objective
- Add a CI job that runs all tests and generates coverage

Changes
- Added a Coverage (Tarpaulin) job to .github/workflows/ci.yml
- Coverage job runs: cargo tarpaulin --workspace --all-features
- Uploads cobertura.xml as a workflow artifact
- Optional Codecov upload (non-blocking)

Acceptance Criteria
- Runs all tests
- Generates coverage report
- Uploads coverage to Codecov (optional)
- Fails on test failures

Closes #230
