### PR TITLE
feat: add basic oracle pattern example

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -21,8 +21,9 @@
 - [Multi-sig patterns](./examples/intermediate.md)
 - [Ajo Factory](./examples/ajo-factory.md)
 
-## Advanced (2 examples)
+## Advanced (3 examples)
 - [Multi-party auth](./examples/advanced.md)
+- [Oracle Pattern](./examples/advanced.md)
 
 # Use Cases
 

--- a/book/src/examples/advanced.md
+++ b/book/src/examples/advanced.md
@@ -29,6 +29,25 @@ if env.ledger().timestamp() < unlock_time {
 }
 ```
 
+---
+
+### [03-oracle-pattern](../examples/advanced/03-oracle-pattern/)
+**Single-source oracle** with authorized submission and freshness validation.
+
+**Key Concepts:**
+- Authorized data updater
+- Ledger-timestamp freshness checks
+- Strict (fail-on-stale) vs raw getters
+- Updater rotation by admin
+
+**Quick Code:**
+```rust
+// Submit data (authorized updater only)
+client.submit(&updater, &42_i128);
+// Query with freshness guard
+let value = client.get_value_strict(); // errors if stale
+```
+
 **[More coming...]** Factories, bonding curves, merkle proofs.
 
 ## ⚠️ Warning

--- a/examples/advanced/03-oracle-pattern/Cargo.toml
+++ b/examples/advanced/03-oracle-pattern/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "oracle-pattern"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/examples/advanced/03-oracle-pattern/README.md
+++ b/examples/advanced/03-oracle-pattern/README.md
@@ -1,0 +1,97 @@
+# Basic Oracle Pattern
+
+A single-source oracle that demonstrates how external data can be submitted by an authorized updater, stored with a timestamp, and queried with freshness validation.
+
+## What You'll Learn
+
+- Implementing an authorized data-submission path
+- Storing timestamped values on-chain
+- Querying data with configurable freshness checks
+- Providing both strict (fail-on-stale) and raw getters
+- Rotating the authorized updater via an admin role
+
+## Overview
+
+```
+Updater submits value + timestamp  →  Readers query latest data
+         ↓                                      ↓
+   Admin can rotate updater           Freshness check (max age)
+```
+
+**Configuration:**
+- `max_age`: maximum seconds before data is considered stale (set at initialization)
+
+## Key Concepts
+
+### Submit Data
+
+Only the authorized updater can submit new values. Each submission records the current ledger timestamp alongside the value.
+
+```rust
+pub fn submit(env: Env, updater: Address, value: i128) -> Result<(), OracleError> {
+    updater.require_auth();
+    env.storage().instance().set(&DataKey::Value, &value);
+    env.storage().instance().set(&DataKey::Timestamp, &env.ledger().timestamp());
+    Ok(())
+}
+```
+
+### Query with Freshness
+
+Readers can fetch the raw value or use a strict getter that rejects stale data:
+
+```rust
+pub fn get_value_strict(env: Env) -> Result<i128, OracleError> {
+    let age = now - last_updated;
+    if age > max_age { return Err(OracleError::StaleData); }
+    // return value
+}
+```
+
+### Freshness Check
+
+```rust
+pub fn is_fresh(env: Env) -> Result<bool, OracleError> {
+    let age = env.ledger().timestamp() - last_submission_timestamp;
+    Ok(age <= max_age)
+}
+```
+
+## Trust Model
+
+| Aspect | Detail |
+|--------|--------|
+| Data source | Single authorized updater — the contract trusts this address |
+| Freshness | Configurable `max_age`; stale data is flagged but not auto-removed |
+| Correctness | Not verified on-chain; freshness != correctness |
+| Extensions | Multi-signer validation, multiple sources, signed payload verification |
+
+**This is a baseline educational example, not a production oracle network.** For production use, consider decentralized aggregation, cryptographic proof of data origin, and economic incentives for honest reporting.
+
+## Error Codes
+
+| Code | Name | Meaning |
+|------|------|---------|
+| 1 | `AlreadyInitialized` | `initialize` called more than once |
+| 2 | `NotInitialized` | Contract not yet initialized |
+| 3 | `NotAuthorized` | Caller is not the authorized updater |
+| 4 | `NoData` | No value has been submitted yet |
+| 5 | `StaleData` | Data exceeds configured max age |
+
+## Security Notes
+
+- Only the authorized updater can submit data
+- Only the admin can rotate the updater
+- Freshness checks reduce stale-data risk but do not prove correctness
+- No value is returned for uninitialized reads
+
+## Running Tests
+
+```bash
+cargo test -p oracle-pattern
+```
+
+## Related Examples
+
+- [02-timelock](../02-timelock/) — Time-based execution with ledger timestamps
+- [01-multi-party-auth](../01-multi-party-auth/) — Multi-party authorization patterns

--- a/examples/advanced/03-oracle-pattern/src/lib.rs
+++ b/examples/advanced/03-oracle-pattern/src/lib.rs
@@ -1,0 +1,206 @@
+//! # Basic Oracle Pattern
+//!
+//! Demonstrates how external data can be submitted by an authorized updater,
+//! stored with a timestamp, and queried with freshness validation.
+//!
+//! ## Trust Model
+//!
+//! - This is a **single-source oracle**: the contract trusts whoever is set as
+//!   the authorized updater. There is no decentralized consensus or multi-signer
+//!   aggregation.
+//! - Freshness checks reduce stale-data risk but do **not** prove correctness
+//!   of the submitted value.
+//! - For production use, consider extending with multi-signer validation,
+//!   multiple independent sources, or signed payload verification.
+
+#![no_std]
+
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env, Symbol,
+};
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum OracleError {
+    /// Contract has already been initialized.
+    AlreadyInitialized = 1,
+    /// Contract has not been initialized yet.
+    NotInitialized = 2,
+    /// Caller is not the authorized updater.
+    NotAuthorized = 3,
+    /// No data has been submitted yet.
+    NoData = 4,
+    /// The stored data is older than the configured max age.
+    StaleData = 5,
+}
+
+// ---------------------------------------------------------------------------
+// Storage keys
+// ---------------------------------------------------------------------------
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    /// The admin who can rotate the updater.
+    Admin,
+    /// The address authorized to submit data.
+    Updater,
+    /// The latest submitted value.
+    Value,
+    /// Ledger timestamp of the last submission.
+    Timestamp,
+    /// Maximum age (seconds) before data is considered stale.
+    MaxAge,
+}
+
+// ---------------------------------------------------------------------------
+// Events
+// ---------------------------------------------------------------------------
+
+const CONTRACT_NS: Symbol = symbol_short!("oracle");
+const ACTION_SUBMIT: Symbol = symbol_short!("submit");
+const ACTION_ADMIN: Symbol = symbol_short!("admin");
+
+/// Event payload for data submissions.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SubmitEventData {
+    pub value: i128,
+    pub timestamp: u64,
+}
+
+// ---------------------------------------------------------------------------
+// Contract
+// ---------------------------------------------------------------------------
+
+#[contract]
+pub struct OracleContract;
+
+#[contractimpl]
+impl OracleContract {
+    /// Initialize the oracle with an admin, an authorized updater, and a
+    /// maximum data age (in seconds).
+    pub fn initialize(
+        env: Env,
+        admin: Address,
+        updater: Address,
+        max_age: u64,
+    ) -> Result<(), OracleError> {
+        if env.storage().instance().has(&DataKey::Admin) {
+            return Err(OracleError::AlreadyInitialized);
+        }
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::Updater, &updater);
+        env.storage().instance().set(&DataKey::MaxAge, &max_age);
+        Ok(())
+    }
+
+    /// Submit a new data value. Only the authorized updater may call this.
+    pub fn submit(env: Env, updater: Address, value: i128) -> Result<(), OracleError> {
+        let stored_updater: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Updater)
+            .ok_or(OracleError::NotInitialized)?;
+
+        if updater != stored_updater {
+            return Err(OracleError::NotAuthorized);
+        }
+        updater.require_auth();
+
+        let now = env.ledger().timestamp();
+        env.storage().instance().set(&DataKey::Value, &value);
+        env.storage().instance().set(&DataKey::Timestamp, &now);
+
+        env.events().publish(
+            (CONTRACT_NS, ACTION_SUBMIT, updater),
+            SubmitEventData {
+                value,
+                timestamp: now,
+            },
+        );
+
+        Ok(())
+    }
+
+    /// Return the latest value regardless of freshness.
+    pub fn get_value(env: Env) -> Result<i128, OracleError> {
+        env.storage()
+            .instance()
+            .get(&DataKey::Value)
+            .ok_or(OracleError::NoData)
+    }
+
+    /// Return the timestamp of the latest submission.
+    pub fn get_timestamp(env: Env) -> Result<u64, OracleError> {
+        env.storage()
+            .instance()
+            .get(&DataKey::Timestamp)
+            .ok_or(OracleError::NoData)
+    }
+
+    /// Return `true` if the stored data is within the configured max age.
+    pub fn is_fresh(env: Env) -> Result<bool, OracleError> {
+        let ts: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::Timestamp)
+            .ok_or(OracleError::NoData)?;
+        let max_age: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MaxAge)
+            .ok_or(OracleError::NotInitialized)?;
+        let age = env.ledger().timestamp().saturating_sub(ts);
+        Ok(age <= max_age)
+    }
+
+    /// Return the latest value only if it is fresh; otherwise error.
+    pub fn get_value_strict(env: Env) -> Result<i128, OracleError> {
+        let ts: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::Timestamp)
+            .ok_or(OracleError::NoData)?;
+        let max_age: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MaxAge)
+            .ok_or(OracleError::NotInitialized)?;
+        let age = env.ledger().timestamp().saturating_sub(ts);
+        if age > max_age {
+            return Err(OracleError::StaleData);
+        }
+        env.storage()
+            .instance()
+            .get(&DataKey::Value)
+            .ok_or(OracleError::NoData)
+    }
+
+    /// Rotate the authorized updater. Only the admin may call this.
+    pub fn set_updater(env: Env, new_updater: Address) -> Result<(), OracleError> {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(OracleError::NotInitialized)?;
+        admin.require_auth();
+
+        env.storage()
+            .instance()
+            .set(&DataKey::Updater, &new_updater);
+
+        env.events()
+            .publish((CONTRACT_NS, ACTION_ADMIN, admin), symbol_short!("rotate"));
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/examples/advanced/03-oracle-pattern/src/test.rs
+++ b/examples/advanced/03-oracle-pattern/src/test.rs
@@ -1,0 +1,177 @@
+use super::*;
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    Address, Env,
+};
+
+fn setup() -> (Env, Address, Address, OracleContractClient<'static>) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, OracleContract);
+    let client = OracleContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let updater = Address::generate(&env);
+    let max_age: u64 = 300; // 5 minutes
+    client.initialize(&admin, &updater, &max_age);
+    (env, admin, updater, client)
+}
+
+// ── initialization ──────────────────────────────────────────────────────────
+
+#[test]
+fn test_initialize_success() {
+    let (_env, _admin, _updater, _client) = setup();
+}
+
+#[test]
+fn test_initialize_twice_fails() {
+    let (env, admin, updater, client) = setup();
+    let result = client.try_initialize(&admin, &updater, &300);
+    assert_eq!(result, Err(Ok(OracleError::AlreadyInitialized)));
+    let _ = env;
+}
+
+// ── submit ──────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_submit_authorized() {
+    let (_env, _admin, updater, client) = setup();
+    client.submit(&updater, &42_i128);
+    assert_eq!(client.get_value(), 42_i128);
+}
+
+#[test]
+fn test_submit_unauthorized() {
+    let (env, _admin, _updater, client) = setup();
+    let stranger = Address::generate(&env);
+    let result = client.try_submit(&stranger, &99_i128);
+    assert_eq!(result, Err(Ok(OracleError::NotAuthorized)));
+}
+
+#[test]
+fn test_submit_updates_value() {
+    let (_env, _admin, updater, client) = setup();
+    client.submit(&updater, &100_i128);
+    assert_eq!(client.get_value(), 100_i128);
+    client.submit(&updater, &200_i128);
+    assert_eq!(client.get_value(), 200_i128);
+}
+
+// ── timestamp ───────────────────────────────────────────────────────────────
+
+#[test]
+fn test_timestamp_stored() {
+    let (env, _admin, updater, client) = setup();
+    let before = env.ledger().timestamp();
+    client.submit(&updater, &10_i128);
+    let ts = client.get_timestamp();
+    assert_eq!(ts, before);
+}
+
+#[test]
+fn test_timestamp_updates() {
+    let (env, _admin, updater, client) = setup();
+    client.submit(&updater, &10_i128);
+    let ts1 = client.get_timestamp();
+    env.ledger().with_mut(|l| l.timestamp += 60);
+    client.submit(&updater, &20_i128);
+    let ts2 = client.get_timestamp();
+    assert!(ts2 > ts1);
+}
+
+// ── freshness ───────────────────────────────────────────────────────────────
+
+#[test]
+fn test_fresh_immediately_after_submit() {
+    let (_env, _admin, updater, client) = setup();
+    client.submit(&updater, &10_i128);
+    assert!(client.is_fresh());
+}
+
+#[test]
+fn test_stale_after_max_age() {
+    let (env, _admin, updater, client) = setup();
+    client.submit(&updater, &10_i128);
+    // advance past max_age (300s)
+    env.ledger().with_mut(|l| l.timestamp += 301);
+    assert!(!client.is_fresh());
+}
+
+#[test]
+fn test_strict_get_succeeds_when_fresh() {
+    let (_env, _admin, updater, client) = setup();
+    client.submit(&updater, &42_i128);
+    assert_eq!(client.get_value_strict(), 42_i128);
+}
+
+#[test]
+fn test_strict_get_fails_when_stale() {
+    let (env, _admin, updater, client) = setup();
+    client.submit(&updater, &42_i128);
+    env.ledger().with_mut(|l| l.timestamp += 301);
+    let result = client.try_get_value_strict();
+    assert_eq!(result, Err(Ok(OracleError::StaleData)));
+}
+
+// ── no-data reads ───────────────────────────────────────────────────────────
+
+#[test]
+fn test_get_value_no_data() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, OracleContract);
+    let client = OracleContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let updater = Address::generate(&env);
+    client.initialize(&admin, &updater, &300);
+    let result = client.try_get_value();
+    assert_eq!(result, Err(Ok(OracleError::NoData)));
+}
+
+#[test]
+fn test_is_fresh_no_data() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, OracleContract);
+    let client = OracleContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let updater = Address::generate(&env);
+    client.initialize(&admin, &updater, &300);
+    let result = client.try_is_fresh();
+    assert_eq!(result, Err(Ok(OracleError::NoData)));
+}
+
+// ── updater rotation ────────────────────────────────────────────────────────
+
+#[test]
+fn test_rotate_updater() {
+    let (env, _admin, updater, client) = setup();
+    let new_updater = Address::generate(&env);
+    client.set_updater(&new_updater);
+
+    // old updater should fail
+    let result = client.try_submit(&updater, &10_i128);
+    assert_eq!(result, Err(Ok(OracleError::NotAuthorized)));
+
+    // new updater should succeed
+    client.submit(&new_updater, &99_i128);
+    assert_eq!(client.get_value(), 99_i128);
+}
+
+// ── auth guard on set_updater ───────────────────────────────────────────────
+
+#[test]
+#[should_panic(expected = "HostError: Error(Auth, InvalidAction)")]
+fn test_set_updater_unauthorized() {
+    let env = Env::default();
+    // no mock_all_auths
+    let contract_id = env.register_contract(None, OracleContract);
+    let client = OracleContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let updater = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin, &updater, &300);
+    env.set_auths(&[]);
+    let stranger = Address::generate(&env);
+    client.set_updater(&stranger);
+}

--- a/examples/advanced/README.md
+++ b/examples/advanced/README.md
@@ -7,9 +7,15 @@ This category contains examples of complex systems and advanced architectural pa
 - **Complex Authorization**: Patterns like threshold signatures and multi-party authorization for high-security applications.
 - **State Machines**: Contracts that implement complex, multi-step workflows like time-delayed execution.
 - **Gas & Ledger Optimization**: Techniques for building highly efficient and scalable contracts.
+- **Oracle Patterns**: Single-source oracle with authorized submission and freshness validation.
+
+## Implemented Examples
+
+- [`01-multi-party-auth`](./01-multi-party-auth/) — Multi-party authorization patterns
+- [`02-timelock`](./02-timelock/) — Time-delayed execution
+- [`03-oracle-pattern`](./03-oracle-pattern/) — Basic oracle with freshness checks
 
 ## Planned Examples
 
-- `03-oracle-integration`: A contract that consumes data from an external oracle.
 - `04-atomic-swaps`: A trustless, cross-contract asset swap.
 - `05-payment-channels`: A basic state channel implementation for off-chain transactions.


### PR DESCRIPTION
## Description

Adds two new Soroban smart contract examples to the cookbook:

1. **Basic Oracle Pattern** (`examples/advanced/03-oracle-pattern/`) — Demonstrates authorized external data submission, timestamped storage, and configurable freshness validation using a single-source oracle model.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [x] New example or improvement to existing example

## Related Issues

Closes #497

## Changes Made

- Added `examples/advanced/03-oracle-pattern/` — contract (`initialize`, `submit`, `get_value`, `get_timestamp`, `is_fresh`, `get_value_strict`, `set_updater`), 15 unit tests, `Cargo.toml`, `README.md`
- Added `examples/intermediate/03-pause-unpause/` — contract (`initialize`, `pause`, `unpause`, `increment`, `reset`, `get_counter`, `is_paused`), 13 unit tests, `Cargo.toml`, `README.md`
- Updated `examples/advanced/README.md` — added oracle pattern to implemented examples
- Updated `examples/intermediate/README.md` — added pause/unpause to implemented examples
- Updated `book/src/examples/advanced.md` — added oracle pattern section with key concepts and quick code
- Updated `book/src/examples/intermediate.md` — added pause/unpause section with key concepts and quick code
- Updated `book/src/SUMMARY.md` — updated example counts and added navigation links

## Testing

### Test Steps

1. `cargo test -p oracle-pattern --target x86_64-unknown-linux-gnu`
2. `cargo test -p pause-unpause --target x86_64-unknown-linux-gnu`
3. `cargo clippy -p oracle-pattern -- -D warnings`
4. `cargo clippy -p pause-unpause -- -D warnings`
5. `rustfmt --check` on all new source files

### Test Results

```bash
# Oracle Pattern
running 15 tests
test test::test_initialize_success ... ok
test test::test_initialize_twice_fails ... ok
test test::test_submit_authorized ... ok
test test::test_submit_unauthorized ... ok
test test::test_submit_updates_value ... ok
test test::test_timestamp_stored ... ok
test test::test_timestamp_updates ... ok
test test::test_fresh_immediately_after_submit ... ok
test test::test_stale_after_max_age ... ok
test test::test_strict_get_succeeds_when_fresh ... ok
test test::test_strict_get_fails_when_stale ... ok
test test::test_get_value_no_data ... ok
test test::test_is_fresh_no_data ... ok
test test::test_rotate_updater ... ok
test test::test_set_updater_unauthorized - should panic ... ok
test result: ok. 15 passed; 0 failed; 0 ignored

# Pause / Unpause
running 13 tests
test test::test_initialize_success ... ok
test test::test_initialize_twice_fails ... ok
test test::test_admin_can_pause ... ok
test test::test_admin_can_unpause ... ok
test test::test_pause_already_paused ... ok
test test::test_unpause_already_unpaused ... ok
test test::test_non_admin_cannot_pause - should panic ... ok
test test::test_non_admin_cannot_unpause - should panic ... ok
test test::test_increment_works_when_unpaused ... ok
test test::test_increment_fails_when_paused ... ok
test test::test_increment_works_again_after_unpause ... ok
test test::test_reset_fails_when_paused ... ok
test test::test_read_only_works_while_paused ... ok
test result: ok. 13 passed; 0 failed; 0 ignored
```

## Checklist

### Code Quality
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] All contracts use `#![no_std]`
- [x] Custom errors use `#[contracterror]` where applicable

### Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

### Documentation
- [x] I have made corresponding changes to the documentation
- [x] I have added/updated the example's README.md (if this is a new/modified example)
- [x] I have updated SUMMARY.md if adding new content to the book

### Pre-submission Validation
- [x] Code formatting passes: `rustfmt --check`
- [x] Linting passes with no warnings: `cargo clippy -p oracle-pattern -p pause-unpause -- -D warnings`
- [x] All tests pass: `cargo test -p oracle-pattern -p pause-unpause --target x86_64-unknown-linux-gnu`
- [x] WASM build succeeds (clippy default target = wasm32-unknown-unknown)

### Other
- [x] I have read the [CONTRIBUTING.md](https://github.com/Soroban-Cookbook/Soroban-Cookbook-/blob/main/CONTRIBUTING.md) guidelines

## Additional Notes

Both examples follow existing repo conventions: `#![no_std]`, `#[contracterror]` enums, `contracttype` DataKey enums, `env.events().publish()` for events, `env.ledger().timestamp()` for time, and `require_auth()` for access control. The oracle example reuses the timestamp/freshness pattern from the timelock example, and the pause example mirrors the multi-sig auth pattern.
