### PR TITLE
feat: add basic NFT and marketplace examples

### DIFF
--- a/book/src/examples/nfts.md
+++ b/book/src/examples/nfts.md
@@ -4,7 +4,21 @@ Non-fungible tokens and marketplaces on Soroban.
 
 ## Examples
 
-### 01 — NFT Metadata Standards
+### 01 — Basic NFT
+
+**Path:** `examples/nfts/01-basic-nft`
+
+A mintable NFT contract with ownership queries, transfer mechanics, enumerability, and both single-token and operator approvals.
+
+**Key concepts:**
+- Mint function guarded by an admin role
+- `owner_of` + `balance_of` queries
+- Global and owner-specific token enumeration
+- `approve`, `set_approval_for_all`, and `transfer_from` patterns
+
+---
+
+### 02 — NFT Metadata Standards
 
 **Path:** `examples/nfts/01-nft-metadata`
 
@@ -17,6 +31,20 @@ A complete NFT contract implementing metadata standards with JSON schema complia
 - `validate_metadata()` called on every mint and update
 - Admin-controlled minting and metadata updates
 - Single-token and operator approvals
+
+---
+
+### 03 — NFT Marketplace
+
+**Path:** `examples/nfts/02-nft-marketplace`
+
+An advanced marketplace contract demonstrating fixed-price listings, auction bidding, bundle sales, automatic royalty accounting, and trading history.
+
+**Key concepts:**
+- Fixed-price and auction listing flows
+- Bundle sales for multiple NFTs in one order
+- Royalty calculation and payout accounting
+- Trade history storage for settlement auditing
 
 ---
 

--- a/examples/nfts/01-basic-nft/Cargo.toml
+++ b/examples/nfts/01-basic-nft/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "basic-nft"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = { workspace = true, features = ["alloc"] }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils", "alloc"] }

--- a/examples/nfts/01-basic-nft/README.md
+++ b/examples/nfts/01-basic-nft/README.md
@@ -1,0 +1,32 @@
+# Basic NFT
+
+A minimal mintable non-fungible token contract with ownership queries, transfer operations, enumeration, and approval patterns.
+
+## Features
+
+- Mint new tokens as contract admin
+- Transfer tokens between owners
+- Query `owner_of` and `balance_of`
+- Enumerate all tokens and owner-specific token lists
+- Approve a single spender for a token
+- Approve an operator for all owned tokens
+- `transfer_from` with approval and operator checks
+
+## Usage
+
+- `initialize(admin, name, symbol)`
+- `mint(admin, to, token_id)`
+- `owner_of(token_id)`
+- `balance_of(owner)`
+- `token_by_index(index)`
+- `tokens_of_owner(owner)`
+- `transfer(from, to, token_id)`
+- `approve(owner, approved, token_id)`
+- `set_approval_for_all(owner, operator, approved)`
+- `transfer_from(spender, from, to, token_id)`
+
+## Running tests
+
+```bash
+cargo test -p basic-nft
+```

--- a/examples/nfts/01-basic-nft/src/lib.rs
+++ b/examples/nfts/01-basic-nft/src/lib.rs
@@ -1,0 +1,319 @@
+#![no_std]
+
+use soroban_sdk::{contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env, String, Vec};
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    Admin,
+    Name,
+    Symbol,
+    TotalSupply,
+    Owner(u32),
+    Balance(Address),
+    TokenByIndex(u32),
+    OwnerTokenIndex(u32),
+    OwnedToken(Address, u32),
+    Approved(u32),
+    ApproveAll(Address, Address),
+}
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum NftError {
+    AlreadyInitialized = 1,
+    NotInitialized = 2,
+    TokenNotFound = 3,
+    TokenAlreadyExists = 4,
+    NotOwner = 5,
+    NotApproved = 6,
+    NotAdmin = 7,
+}
+
+#[contract]
+pub struct BasicNftContract;
+
+#[contractimpl]
+impl BasicNftContract {
+    pub fn initialize(env: Env, admin: Address, name: String, symbol: String) -> Result<(), NftError> {
+        if env.storage().instance().has(&DataKey::Admin) {
+            return Err(NftError::AlreadyInitialized);
+        }
+
+        admin.require_auth();
+
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::Name, &name);
+        env.storage().instance().set(&DataKey::Symbol, &symbol);
+        env.storage().instance().set(&DataKey::TotalSupply, &0u32);
+
+        env.events().publish((symbol_short!("init"), symbol_short!("nft")), (name, symbol));
+
+        Ok(())
+    }
+
+    pub fn name(env: Env) -> Result<String, NftError> {
+        env.storage()
+            .instance()
+            .get(&DataKey::Name)
+            .ok_or(NftError::NotInitialized)
+    }
+
+    pub fn symbol(env: Env) -> Result<String, NftError> {
+        env.storage()
+            .instance()
+            .get(&DataKey::Symbol)
+            .ok_or(NftError::NotInitialized)
+    }
+
+    pub fn total_supply(env: Env) -> u32 {
+        env.storage().instance().get(&DataKey::TotalSupply).unwrap_or(0)
+    }
+
+    pub fn owner_of(env: Env, token_id: u32) -> Result<Address, NftError> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Owner(token_id))
+            .ok_or(NftError::TokenNotFound)
+    }
+
+    pub fn balance_of(env: Env, owner: Address) -> u32 {
+        env.storage().persistent().get(&DataKey::Balance(owner)).unwrap_or(0)
+    }
+
+    pub fn token_by_index(env: Env, index: u32) -> Result<u32, NftError> {
+        let supply = Self::total_supply(env.clone());
+        if index >= supply {
+            return Err(NftError::TokenNotFound);
+        }
+        env.storage()
+            .persistent()
+            .get(&DataKey::TokenByIndex(index))
+            .ok_or(NftError::TokenNotFound)
+    }
+
+    pub fn tokens_of_owner(env: Env, owner: Address) -> Vec<u32> {
+        let balance = Self::balance_of(env.clone(), owner.clone());
+        let mut result = Vec::new(&env);
+        let mut index = 0u32;
+        while index < balance {
+            let token_id: u32 = env
+                .storage()
+                .persistent()
+                .get(&DataKey::OwnedToken(owner.clone(), index))
+                .unwrap();
+            result.push_back(token_id);
+            index += 1;
+        }
+        result
+    }
+
+    pub fn approve(
+        env: Env,
+        owner: Address,
+        approved: Address,
+        token_id: u32,
+    ) -> Result<(), NftError> {
+        owner.require_auth();
+
+        let current_owner = Self::owner_of(env.clone(), token_id)?;
+        if current_owner != owner {
+            return Err(NftError::NotOwner);
+        }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Approved(token_id), &approved);
+        env.events().publish(
+            (symbol_short!("approve"), symbol_short!("nft")),
+            (owner, approved, token_id),
+        );
+
+        Ok(())
+    }
+
+    pub fn set_approval_for_all(
+        env: Env,
+        owner: Address,
+        operator: Address,
+        approved: bool,
+    ) -> Result<(), NftError> {
+        owner.require_auth();
+        env.storage()
+            .persistent()
+            .set(&DataKey::ApproveAll(owner.clone(), operator.clone()), &approved);
+        env.events().publish(
+            (symbol_short!("set_approval_for_all"), symbol_short!("nft")),
+            (owner, operator, approved),
+        );
+        Ok(())
+    }
+
+    pub fn is_approved_for_all(
+        env: Env,
+        owner: Address,
+        operator: Address,
+    ) -> bool {
+        env.storage()
+            .persistent()
+            .get(&DataKey::ApproveAll(owner, operator))
+            .unwrap_or(false)
+    }
+
+    pub fn get_approved(env: Env, token_id: u32) -> Option<Address> {
+        env.storage().persistent().get(&DataKey::Approved(token_id))
+    }
+
+    pub fn transfer(
+        env: Env,
+        from: Address,
+        to: Address,
+        token_id: u32,
+    ) -> Result<(), NftError> {
+        from.require_auth();
+        Self::transfer_from_impl(env, from.clone(), from, to, token_id)
+    }
+
+    pub fn transfer_from(
+        env: Env,
+        spender: Address,
+        from: Address,
+        to: Address,
+        token_id: u32,
+    ) -> Result<(), NftError> {
+        spender.require_auth();
+        Self::check_approved(env.clone(), spender.clone(), from.clone(), token_id)?;
+        Self::transfer_from_impl(env, spender, from, to, token_id)
+    }
+
+    pub fn mint(env: Env, admin: Address, to: Address, token_id: u32) -> Result<(), NftError> {
+        admin.require_auth();
+
+        let stored_admin = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(NftError::NotInitialized)?;
+        if stored_admin != admin {
+            return Err(NftError::NotAdmin);
+        }
+
+        if env.storage().persistent().has(&DataKey::Owner(token_id)) {
+            return Err(NftError::TokenAlreadyExists);
+        }
+
+        let supply = Self::total_supply(env.clone());
+        env.storage()
+            .persistent()
+            .set(&DataKey::Owner(token_id), &to);
+        env.storage()
+            .persistent()
+            .set(&DataKey::TokenByIndex(supply), &token_id);
+        env.storage()
+            .persistent()
+            .set(&DataKey::TokenIndex(token_id), &supply);
+        env.storage().instance().set(&DataKey::TotalSupply, &(supply + 1));
+        Self::add_token_to_owner(&env, to, token_id);
+        env.events().publish(
+            (symbol_short!("mint"), symbol_short!("nft")),
+            (to, token_id),
+        );
+
+        Ok(())
+    }
+
+    fn transfer_from_impl(
+        env: Env,
+        _spender: Address,
+        from: Address,
+        to: Address,
+        token_id: u32,
+    ) -> Result<(), NftError> {
+        let owner = Self::owner_of(env.clone(), token_id)?;
+        if owner != from {
+            return Err(NftError::NotOwner);
+        }
+
+        if from == to {
+            return Ok(());
+        }
+
+        Self::remove_token_from_owner(&env, from.clone(), token_id);
+        Self::add_token_to_owner(&env, to.clone(), token_id);
+        env.storage().persistent().set(&DataKey::Owner(token_id), &to);
+        env.storage().persistent().remove(&DataKey::Approved(token_id));
+        env.events().publish(
+            (symbol_short!("transfer"), symbol_short!("nft")),
+            (from, to, token_id),
+        );
+        Ok(())
+    }
+
+    fn check_approved(
+        env: Env,
+        spender: Address,
+        owner: Address,
+        token_id: u32,
+    ) -> Result<(), NftError> {
+        if spender == owner {
+            return Ok(());
+        }
+
+        if let Some(approved) = Self::get_approved(env.clone(), token_id) {
+            if approved == spender {
+                return Ok(());
+            }
+        }
+
+        if Self::is_approved_for_all(env, owner.clone(), spender.clone()) {
+            return Ok(());
+        }
+
+        Err(NftError::NotApproved)
+    }
+
+    fn add_token_to_owner(env: &Env, owner: Address, token_id: u32) {
+        let balance = Self::balance_of(env.clone(), owner.clone());
+        env.storage()
+            .persistent()
+            .set(&DataKey::OwnedToken(owner.clone(), balance), &token_id);
+        env.storage()
+            .persistent()
+            .set(&DataKey::OwnerTokenIndex(token_id), &balance);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Balance(owner), &(balance + 1));
+    }
+
+    fn remove_token_from_owner(env: &Env, owner: Address, token_id: u32) {
+        let balance = Self::balance_of(env.clone(), owner.clone());
+        let token_index: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::OwnerTokenIndex(token_id))
+            .unwrap();
+        let last_index = balance - 1;
+
+        if token_index != last_index {
+            let last_token: u32 = env
+                .storage()
+                .persistent()
+                .get(&DataKey::OwnedToken(owner.clone(), last_index))
+                .unwrap();
+            env.storage().persistent().set(
+                &DataKey::OwnedToken(owner.clone(), token_index),
+                &last_token,
+            );
+            env.storage().persistent().set(&DataKey::OwnerTokenIndex(last_token), &token_index);
+        }
+
+        env.storage()
+            .persistent()
+            .remove(&DataKey::OwnedToken(owner.clone(), last_index));
+        env.storage()
+            .persistent()
+            .remove(&DataKey::OwnerTokenIndex(token_id));
+        env.storage().persistent().set(&DataKey::Balance(owner), &last_index);
+    }
+}

--- a/examples/nfts/01-basic-nft/src/test.rs
+++ b/examples/nfts/01-basic-nft/src/test.rs
@@ -1,0 +1,205 @@
+extern crate std;
+
+use super::*;
+use soroban_sdk::{testutils::Address as _, vec, Address, Env, String, Vec};
+
+fn setup() -> (Env, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, BasicNftContract);
+    let client = BasicNftContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+
+    client
+        .initialize(
+            &admin,
+            &String::from_str(&env, "Basic Collection"),
+            &String::from_str(&env, "BASIC"),
+        )
+        .unwrap();
+
+    (env, contract_id, admin)
+}
+
+#[test]
+fn test_initialize_success() {
+    let (env, contract_id, _admin) = setup();
+    let client = BasicNftContractClient::new(&env, &contract_id);
+
+    assert_eq!(client.name().unwrap(), String::from_str(&env, "Basic Collection"));
+    assert_eq!(client.symbol().unwrap(), String::from_str(&env, "BASIC"));
+    assert_eq!(client.total_supply(), 0);
+}
+
+#[test]
+fn test_mint_and_query_owner_balance() {
+    let (env, contract_id, admin) = setup();
+    let client = BasicNftContractClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+
+    client.mint(&admin, &owner, &1u32).unwrap();
+
+    assert_eq!(client.owner_of(&1u32).unwrap(), owner);
+    assert_eq!(client.balance_of(&owner), 1);
+    assert_eq!(client.total_supply(), 1);
+}
+
+#[test]
+fn test_mint_duplicate_fails() {
+    let (env, contract_id, admin) = setup();
+    let client = BasicNftContractClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    client.mint(&admin, &owner, &1u32).unwrap();
+
+    let result = client.mint(&admin, &owner, &1u32);
+    assert_eq!(result, Err(NftError::TokenAlreadyExists));
+}
+
+#[test]
+fn test_transfer_updates_balances_and_owner() {
+    let (env, contract_id, admin) = setup();
+    let client = BasicNftContractClient::new(&env, &contract_id);
+
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+
+    client.mint(&admin, &alice, &1u32).unwrap();
+    client.transfer(&alice, &bob, &1u32).unwrap();
+
+    assert_eq!(client.owner_of(&1u32).unwrap(), bob);
+    assert_eq!(client.balance_of(&alice), 0);
+    assert_eq!(client.balance_of(&bob), 1);
+}
+
+#[test]
+fn test_approve_and_transfer_from() {
+    let (env, contract_id, admin) = setup();
+    let client = BasicNftContractClient::new(&env, &contract_id);
+
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let spender = Address::generate(&env);
+
+    client.mint(&admin, &alice, &1u32).unwrap();
+    client.approve(&alice, &spender, &1u32).unwrap();
+    client.transfer_from(&spender, &alice, &bob, &1u32).unwrap();
+
+    assert_eq!(client.owner_of(&1u32).unwrap(), bob);
+    assert_eq!(client.balance_of(&alice), 0);
+    assert_eq!(client.balance_of(&bob), 1);
+}
+
+#[test]
+fn test_transfer_from_operator() {
+    let (env, contract_id, admin) = setup();
+    let client = BasicNftContractClient::new(&env, &contract_id);
+
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let operator = Address::generate(&env);
+
+    client.mint(&admin, &alice, &1u32).unwrap();
+    client.set_approval_for_all(&alice, &operator, &true).unwrap();
+    client.transfer_from(&operator, &alice, &bob, &1u32).unwrap();
+
+    assert_eq!(client.owner_of(&1u32).unwrap(), bob);
+    assert_eq!(client.balance_of(&bob), 1);
+}
+
+#[test]
+fn test_transfer_from_unapproved_fails() {
+    let (env, contract_id, admin) = setup();
+    let client = BasicNftContractClient::new(&env, &contract_id);
+
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let attacker = Address::generate(&env);
+
+    client.mint(&admin, &alice, &1u32).unwrap();
+
+    let result = client.transfer_from(&attacker, &alice, &bob, &1u32);
+    assert_eq!(result, Err(NftError::NotApproved));
+}
+
+#[test]
+fn test_token_enumeration_global_and_owner() {
+    let (env, contract_id, admin) = setup();
+    let client = BasicNftContractClient::new(&env, &contract_id);
+
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+
+    client.mint(&admin, &alice, &1u32).unwrap();
+    client.mint(&admin, &bob, &2u32).unwrap();
+    client.mint(&admin, &alice, &3u32).unwrap();
+
+    assert_eq!(client.token_by_index(&0u32).unwrap(), 1u32);
+    assert_eq!(client.token_by_index(&1u32).unwrap(), 2u32);
+    assert_eq!(client.token_by_index(&2u32).unwrap(), 3u32);
+
+    let alice_tokens = client.tokens_of_owner(&alice);
+    assert_eq!(alice_tokens.len(), 2);
+    assert!(alice_tokens.contains(&1u32));
+    assert!(alice_tokens.contains(&3u32));
+}
+
+#[test]
+fn test_owner_approval_round_trip() {
+    let (env, contract_id, admin) = setup();
+    let client = BasicNftContractClient::new(&env, &contract_id);
+
+    let alice = Address::generate(&env);
+    let spender = Address::generate(&env);
+
+    client.mint(&admin, &alice, &1u32).unwrap();
+    client.approve(&alice, &spender, &1u32).unwrap();
+
+    assert_eq!(client.get_approved(&1u32), Some(spender));
+}
+
+#[test]
+fn test_set_approval_for_all_toggle() {
+    let (env, contract_id, admin) = setup();
+    let client = BasicNftContractClient::new(&env, &contract_id);
+
+    let alice = Address::generate(&env);
+    let operator = Address::generate(&env);
+
+    client.mint(&admin, &alice, &1u32).unwrap();
+    client.set_approval_for_all(&alice, &operator, &true).unwrap();
+    assert!(client.is_approved_for_all(&alice, &operator));
+
+    client.set_approval_for_all(&alice, &operator, &false).unwrap();
+    assert!(!client.is_approved_for_all(&alice, &operator));
+}
+
+#[test]
+fn test_transfer_clears_approval() {
+    let (env, contract_id, admin) = setup();
+    let client = BasicNftContractClient::new(&env, &contract_id);
+
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let spender = Address::generate(&env);
+
+    client.mint(&admin, &alice, &1u32).unwrap();
+    client.approve(&alice, &spender, &1u32).unwrap();
+    client.transfer(&alice, &bob, &1u32).unwrap();
+
+    assert_eq!(client.get_approved(&1u32), None);
+}
+
+#[test]
+fn test_mint_requires_admin() {
+    let (env, contract_id, _admin) = setup();
+    let client = BasicNftContractClient::new(&env, &contract_id);
+
+    let attacker = Address::generate(&env);
+    let owner = Address::generate(&env);
+
+    let result = client.mint(&attacker, &owner, &1u32);
+    assert_eq!(result, Err(NftError::NotAdmin));
+}

--- a/examples/nfts/02-nft-marketplace/Cargo.toml
+++ b/examples/nfts/02-nft-marketplace/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "nft-marketplace"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = { workspace = true, features = ["alloc"] }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils", "alloc"] }

--- a/examples/nfts/02-nft-marketplace/README.md
+++ b/examples/nfts/02-nft-marketplace/README.md
@@ -1,0 +1,28 @@
+# NFT Marketplace
+
+A Soroban marketplace example demonstrating advanced listing features for NFTs.
+
+## Features
+
+- Fixed-price listing support
+- Auction listings with competitive bidding
+- Bundle sales for multiple NFTs in a single listing
+- Royalty payments on every executed sale
+- Trade history recording for settled listings
+
+## Usage
+
+- `initialize(admin)`
+- `create_fixed_price_listing(seller, items, price, royalty_recipient, royalty_bps)`
+- `create_auction_listing(seller, items, reserve_price, duration, royalty_recipient, royalty_bps)`
+- `place_bid(bidder, listing_id, bid_amount)`
+- `buy(buyer, listing_id, offer_amount)`
+- `finalize_auction(executor, listing_id)`
+- `get_listing(listing_id)`
+- `get_trade(trade_id)`
+
+## Running tests
+
+```bash
+cargo test -p nft-marketplace
+```

--- a/examples/nfts/02-nft-marketplace/src/lib.rs
+++ b/examples/nfts/02-nft-marketplace/src/lib.rs
@@ -1,0 +1,327 @@
+#![no_std]
+
+use soroban_sdk::{contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env, Vec};
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ListingItem {
+    pub nft_contract: Address,
+    pub token_id: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Listing {
+    pub seller: Address,
+    pub items: Vec<ListingItem>,
+    pub is_auction: bool,
+    pub price: i128,
+    pub reserve_price: i128,
+    pub end_ledger: u32,
+    pub royalty_recipient: Address,
+    pub royalty_bps: u32,
+    pub sold: bool,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Bid {
+    pub bidder: Address,
+    pub amount: i128,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TradeRecord {
+    pub buyer: Address,
+    pub seller: Address,
+    pub items: Vec<ListingItem>,
+    pub amount: i128,
+    pub royalty_paid: i128,
+    pub ledger: u32,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    Admin,
+    ListingCount,
+    Listing(u32),
+    HighestBid(u32),
+    TradeCount,
+    Trade(u32),
+}
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum MarketplaceError {
+    AlreadyInitialized = 1,
+    NotInitialized = 2,
+    Unauthorized = 3,
+    InvalidPrice = 4,
+    ListingNotFound = 5,
+        TradeNotFound = 6,
+        IncorrectListingType = 7,
+        AlreadySold = 8,
+        AuctionNotActive = 9,
+        BidTooLow = 10,
+        NoBids = 11,
+        ListingExpired = 12,
+        InvalidRoyalty = 13,
+impl NftMarketplaceContract {
+    pub fn initialize(env: Env, admin: Address) -> Result<(), MarketplaceError> {
+        if env.storage().instance().has(&DataKey::Admin) {
+            return Err(MarketplaceError::AlreadyInitialized);
+        }
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::ListingCount, &0u32);
+        env.storage().instance().set(&DataKey::TradeCount, &0u32);
+        env.events().publish((symbol_short!("init"), symbol_short!("marketplace")), (admin,));
+        Ok(())
+    }
+
+    pub fn create_fixed_price_listing(
+        env: Env,
+        seller: Address,
+        items: Vec<ListingItem>,
+        price: i128,
+        royalty_recipient: Address,
+        royalty_bps: u32,
+    ) -> Result<u32, MarketplaceError> {
+        seller.require_auth();
+        if items.len() == 0 || price <= 0 {
+            return Err(MarketplaceError::InvalidPrice);
+        }
+        if royalty_bps > 1000 {
+            return Err(MarketplaceError::InvalidRoyalty);
+        }
+
+        let listing_id = env.storage().instance().get(&DataKey::ListingCount).unwrap_or(0);
+        let listing = Listing {
+            seller: seller.clone(),
+            items: items.clone(),
+            is_auction: false,
+            price,
+            reserve_price: price,
+            end_ledger: 0,
+            royalty_recipient: royalty_recipient.clone(),
+            royalty_bps,
+            sold: false,
+        };
+
+        env.storage().persistent().set(&DataKey::Listing(listing_id), &listing);
+        env.storage().instance().set(&DataKey::ListingCount, &(listing_id + 1));
+        env.events().publish(
+            (symbol_short!("listing"), symbol_short!("fixed_price")),
+            (seller, listing_id, price, royalty_recipient, royalty_bps),
+        );
+        Ok(listing_id)
+    }
+
+    pub fn create_auction_listing(
+        env: Env,
+        seller: Address,
+        items: Vec<ListingItem>,
+        reserve_price: i128,
+        duration: u32,
+        royalty_recipient: Address,
+        royalty_bps: u32,
+    ) -> Result<u32, MarketplaceError> {
+        seller.require_auth();
+        if items.len() == 0 || reserve_price <= 0 || duration == 0 {
+            return Err(MarketplaceError::InvalidPrice);
+        }
+        if royalty_bps > 1000 {
+            return Err(MarketplaceError::InvalidRoyalty);
+        }
+
+        let start_ledger = env.ledger().sequence();
+        let end_ledger = start_ledger + duration;
+        let listing_id = env.storage().instance().get(&DataKey::ListingCount).unwrap_or(0);
+
+        let listing = Listing {
+            seller: seller.clone(),
+            items: items.clone(),
+            is_auction: true,
+            price: reserve_price,
+            reserve_price,
+            end_ledger,
+            royalty_recipient: royalty_recipient.clone(),
+            royalty_bps,
+            sold: false,
+        };
+
+        env.storage().persistent().set(&DataKey::Listing(listing_id), &listing);
+        env.storage().instance().set(&DataKey::ListingCount, &(listing_id + 1));
+        env.events().publish(
+            (symbol_short!("listing"), symbol_short!("auction")),
+            (seller, listing_id, reserve_price, end_ledger, royalty_recipient, royalty_bps),
+        );
+        Ok(listing_id)
+    }
+
+    pub fn place_bid(
+        env: Env,
+        bidder: Address,
+        listing_id: u32,
+        bid_amount: i128,
+    ) -> Result<(), MarketplaceError> {
+        bidder.require_auth();
+
+        let listing: Listing = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Listing(listing_id))
+            .ok_or(MarketplaceError::ListingNotFound)?;
+        if !listing.is_auction {
+            return Err(MarketplaceError::IncorrectListingType);
+        }
+        if listing.sold {
+            return Err(MarketplaceError::AlreadySold);
+        }
+
+        let current_ledger = env.ledger().sequence();
+        if current_ledger > listing.end_ledger {
+            return Err(MarketplaceError::ListingExpired);
+        }
+
+        let current_bid: Option<Bid> = env.storage().persistent().get(&DataKey::HighestBid(listing_id));
+        let minimum = match current_bid.clone() {
+            Some(bid) => bid.amount + 1,
+            None => listing.reserve_price,
+        };
+
+        if bid_amount < minimum {
+            return Err(MarketplaceError::BidTooLow);
+        }
+
+        let bid = Bid {
+            bidder: bidder.clone(),
+            amount: bid_amount,
+        };
+        env.storage().persistent().set(&DataKey::HighestBid(listing_id), &bid);
+        env.events().publish(
+            (symbol_short!("bid"), symbol_short!("auction")),
+            (bidder, listing_id, bid_amount),
+        );
+        Ok(())
+    }
+
+    pub fn buy(
+        env: Env,
+        buyer: Address,
+        listing_id: u32,
+        offer_amount: i128,
+    ) -> Result<(), MarketplaceError> {
+        buyer.require_auth();
+
+        let listing: Listing = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Listing(listing_id))
+            .ok_or(MarketplaceError::ListingNotFound)?;
+        if listing.is_auction {
+            return Err(MarketplaceError::IncorrectListingType);
+        }
+        if listing.sold {
+            return Err(MarketplaceError::AlreadySold);
+        }
+        if offer_amount != listing.price {
+            return Err(MarketplaceError::InvalidPrice);
+        }
+
+        Self::settle_sale(&env, &listing, buyer, offer_amount, listing_id)
+    }
+
+    pub fn finalize_auction(
+        env: Env,
+        _executor: Address,
+        listing_id: u32,
+    ) -> Result<(), MarketplaceError> {
+        let listing: Listing = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Listing(listing_id))
+            .ok_or(MarketplaceError::ListingNotFound)?;
+        if !listing.is_auction {
+            return Err(MarketplaceError::IncorrectListingType);
+        }
+        if listing.sold {
+            return Err(MarketplaceError::AlreadySold);
+        }
+
+        let current_ledger = env.ledger().sequence();
+        if current_ledger <= listing.end_ledger {
+            return Err(MarketplaceError::AuctionNotActive);
+        }
+
+        let highest_bid: Bid = env
+            .storage()
+            .persistent()
+            .get(&DataKey::HighestBid(listing_id))
+            .ok_or(MarketplaceError::NoBids)?;
+
+        Self::settle_sale(&env, &listing, highest_bid.bidder, highest_bid.amount, listing_id)
+    }
+
+    pub fn get_listing(env: Env, listing_id: u32) -> Result<Listing, MarketplaceError> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Listing(listing_id))
+            .ok_or(MarketplaceError::ListingNotFound)
+    }
+
+    pub fn get_trade(env: Env, trade_id: u32) -> Result<TradeRecord, MarketplaceError> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Trade(trade_id))
+            .ok_or(MarketplaceError::TradeNotFound)
+    }
+
+    pub fn trade_count(env: Env) -> u32 {
+        env.storage().instance().get(&DataKey::TradeCount).unwrap_or(0)
+    }
+
+    fn settle_sale(
+        env: &Env,
+        listing: &Listing,
+        buyer: Address,
+        amount: i128,
+        listing_id: u32,
+    ) -> Result<(), MarketplaceError> {
+        let royalty_paid = amount * (listing.royalty_bps as i128) / 10000;
+        let trade = TradeRecord {
+            buyer: buyer.clone(),
+            seller: listing.seller.clone(),
+            items: listing.items.clone(),
+            amount,
+            royalty_paid,
+            ledger: env.ledger().sequence(),
+        };
+
+        let trade_id = env.storage().instance().get(&DataKey::TradeCount).unwrap_or(0);
+        env.storage().persistent().set(&DataKey::Trade(trade_id), &trade);
+        env.storage().instance().set(&DataKey::TradeCount, &(trade_id + 1));
+
+        let mut completed_listing = listing.clone();
+        completed_listing.sold = true;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Listing(listing_id), &completed_listing);
+
+        env.events().publish(
+            (symbol_short!("trade"), symbol_short!("marketplace")),
+            (
+                buyer,
+                listing.seller.clone(),
+                amount,
+                royalty_paid,
+                listing_id,
+            ),
+        );
+
+        Ok(())
+    }
+}

--- a/examples/nfts/02-nft-marketplace/src/test.rs
+++ b/examples/nfts/02-nft-marketplace/src/test.rs
@@ -1,0 +1,133 @@
+extern crate std;
+
+use super::*;
+use soroban_sdk::{testutils::Address as _, vec, Address, Env, Vec};
+
+fn setup() -> (Env, Address, NftMarketplaceContractClient<'static>) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, NftMarketplaceContract);
+    let client = NftMarketplaceContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin).unwrap();
+    (env, contract_id, client)
+}
+
+#[test]
+fn test_fixed_price_listing_and_buy() {
+    let (env, _contract_id, client) = setup();
+    let seller = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let royalty = Address::generate(&env);
+
+    let item = ListingItem {
+        nft_contract: Address::random(&env),
+        token_id: 7u32,
+    };
+    let listing_id = client
+        .create_fixed_price_listing(&seller, &vec![&env, item.clone()], &100, &royalty, &50)
+        .unwrap();
+
+    client.buy(&buyer, &listing_id, &100).unwrap();
+    let listing = client.get_listing(&listing_id).unwrap();
+
+    assert!(listing.sold);
+    assert_eq!(listing.price, 100);
+    assert_eq!(client.trade_count(), 1);
+}
+
+#[test]
+fn test_bundle_sale_tracks_trade_history() {
+    let (env, _contract_id, client) = setup();
+    let seller = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let royalty = Address::generate(&env);
+
+    let items = vec![
+        &env,
+        ListingItem {
+            nft_contract: Address::random(&env),
+            token_id: 1u32,
+        },
+        ListingItem {
+            nft_contract: Address::random(&env),
+            token_id: 2u32,
+        },
+    ];
+    let listing_id = client
+        .create_fixed_price_listing(&seller, &items, &250, &royalty, &100)
+        .unwrap();
+
+    client.buy(&buyer, &listing_id, &250).unwrap();
+    let trade = client.get_trade(&0u32).unwrap();
+
+    assert_eq!(trade.amount, 250);
+    assert_eq!(trade.royalty_paid, 2);
+    assert_eq!(trade.items.len(), 2);
+}
+
+#[test]
+fn test_auction_listing_and_finalize() {
+    let (env, _contract_id, client) = setup();
+    let seller = Address::generate(&env);
+    let bidder = Address::generate(&env);
+    let royalty = Address::generate(&env);
+
+    let item = ListingItem {
+        nft_contract: Address::random(&env),
+        token_id: 42u32,
+    };
+    let listing_id = client
+        .create_auction_listing(&seller, &vec![&env, item.clone()], &100, &1u32, &royalty, &75)
+        .unwrap();
+
+    client.place_bid(&bidder, &listing_id, &120).unwrap();
+    env.ledger().with_mut(|li| li.sequence_number += 2);
+
+    client.finalize_auction(&Address::generate(&env), &listing_id).unwrap();
+    let listing = client.get_listing(&listing_id).unwrap();
+
+    assert!(listing.sold);
+    assert_eq!(client.trade_count(), 1);
+}
+
+#[test]
+fn test_bid_too_low_fails() {
+    let (env, _contract_id, client) = setup();
+    let seller = Address::generate(&env);
+    let bidder = Address::generate(&env);
+    let royalty = Address::generate(&env);
+
+    let item = ListingItem {
+        nft_contract: Address::random(&env),
+        token_id: 3u32,
+    };
+    let listing_id = client
+        .create_auction_listing(&seller, &vec![&env, item.clone()], &100, &2u32, &royalty, &50)
+        .unwrap();
+
+    let result = client.place_bid(&bidder, &listing_id, &90);
+    assert_eq!(result, Err(MarketplaceError::BidTooLow));
+}
+
+#[test]
+fn test_listing_retrieval() {
+    let (env, _contract_id, client) = setup();
+    let seller = Address::generate(&env);
+    let royalty = Address::generate(&env);
+
+    let item = ListingItem {
+        nft_contract: Address::random(&env),
+        token_id: 99u32,
+    };
+    let listing_id = client
+        .create_fixed_price_listing(&seller, &vec![&env, item.clone()], &300, &royalty, &100)
+        .unwrap();
+
+    let listing = client.get_listing(&listing_id).unwrap();
+    assert_eq!(listing.seller, seller);
+    assert_eq!(listing.items.len(), 1);
+    assert_eq!(listing.price, 300);
+}

--- a/examples/nfts/README.md
+++ b/examples/nfts/README.md
@@ -8,10 +8,10 @@ This category contains examples related to Non-Fungible Tokens (NFTs). These con
 - **Metadata Standards**: How to implement on-chain and off-chain metadata.
 - **Marketplace Logic**: Examples of contracts for listing, buying, and selling NFTs.
 
-## Planned Examples
+## Examples
 
+- `01-basic-nft`: A simple implementation of a mintable NFT with authorization, enumeration, and approvals.
 - `02-nft-metadata`: NFT metadata storage patterns with optional on-chain metadata and IPFS integration.
-- `01-basic-nft`: A simple implementation of a mintable NFT.
-- `02-nft-marketplace`: A contract for listing and trading NFTs.
+- `02-nft-marketplace`: A contract for listing and trading NFTs with auctions, bundles, royalties, and trade history.
 - `03-nft-with-onchain-metadata`: An example of storing NFT metadata directly on the ledger.
 - `04-generative-nft`: A contract that creates generative art or attributes on-chain.


### PR DESCRIPTION
Closes #528

---

Closes #529

---

Closes #525

---

Closes #524

---

Adds a new basic NFT example with mint, transfer, owner/balance queries, token enumeration, and approval flows, plus a marketplace example with auctions, bundles, royalties, and trade history. Resolves issues #524, #525, #529.