### PR TITLE
feat(advanced): add 05-batch-transfer example

### DIFF
--- a/examples/advanced/05-batch-transfer/Cargo.toml
+++ b/examples/advanced/05-batch-transfer/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "batch-transfer"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = { workspace = true, features = ["alloc"] }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils", "alloc"] }

--- a/examples/advanced/05-batch-transfer/README.md
+++ b/examples/advanced/05-batch-transfer/README.md
@@ -1,0 +1,113 @@
+# 05 — Batch Transfer
+
+Send tokens to multiple recipients in a single, atomic Soroban transaction.
+
+---
+
+## What it does
+
+The `BatchTransferContract` lets a sender transfer different amounts to up to **100 recipients** in one invocation. Because the sender's balance is read once and written once (rather than once per recipient), batch transfers are significantly cheaper on-chain than looping over individual `transfer` calls.
+
+If any validation check fails — empty batch, invalid amount, or insufficient balance — **the entire batch is rejected** and no state is mutated.
+
+---
+
+## Key concepts
+
+| Concept | Where |
+|---------|-------|
+| Single-read / single-write gas optimisation | `batch_transfer` in `src/lib.rs` |
+| Checked arithmetic on totals and per-recipient credits | `checked_add` calls in `batch_transfer` |
+| Atomic all-or-nothing execution | Validation pass before any storage write |
+| `#[contracterror]` enum with typed failures | `BatchError` in `src/lib.rs` |
+| Event per transfer + batch-complete summary event | `TransferEvent`, `BatchCompleteEvent` |
+| `#[contracttype]` for transfer descriptors | `Transfer` struct |
+
+---
+
+## Contract API
+
+### `initialize(admin: Address, initial_supply: i128) → Result<(), BatchError>`
+
+One-time setup. Mints `initial_supply` tokens to `admin`.
+
+Errors: `AlreadyInitialized`, `InvalidAmount`
+
+---
+
+### `batch_transfer(from: Address, transfers: Vec<Transfer>) → Result<u32, BatchError>`
+
+Transfer tokens from `from` to all recipients described in `transfers`.
+
+`from` must authorize the call. Returns the number of recipients credited.
+
+**`Transfer` struct:**
+
+```rust
+pub struct Transfer {
+    pub to: Address,   // recipient
+    pub amount: i128,  // must be > 0
+}
+```
+
+**Error table:**
+
+| Error | Condition |
+|-------|-----------|
+| `NotInitialized` | Contract not yet initialized |
+| `EmptyBatch` | `transfers` is empty |
+| `BatchTooLarge` | More than `MAX_BATCH_SIZE` (100) entries |
+| `InvalidAmount` | Any `amount` ≤ 0 |
+| `TotalOverflow` | Sum of all amounts overflows `i128` |
+| `InsufficientBalance` | Sender balance < total |
+| `RecipientOverflow` | A recipient's new balance would overflow `i128` |
+
+---
+
+### `balance(user: Address) → i128`
+
+Returns the current token balance for `user`.
+
+---
+
+## Gas optimisation explained
+
+A naïve implementation of multi-recipient transfers loops and calls a `transfer` function per recipient. Each call reads and writes the sender's balance. For N recipients that is 2N storage operations on the sender's balance alone.
+
+This example reads the sender's balance **once**, validates the full batch, then:
+1. Writes the sender's new balance **once** (deducting the total)
+2. Reads and writes each recipient's balance exactly once
+
+Total storage ops = `1 read + 1 write` (sender) + `N reads + N writes` (recipients) = `2 + 2N` instead of `2N + 2N = 4N` for naïve looping.
+
+---
+
+## How to build and test
+
+```bash
+# Run unit tests
+cargo test -p batch-transfer
+
+# Build WASM release binary
+cargo build --target wasm32-unknown-unknown --release -p batch-transfer
+
+# Lint
+cargo clippy -p batch-transfer --all-targets -- -D warnings
+```
+
+---
+
+## Use cases
+
+- **Payroll / airdrop** — distribute stablecoin salaries or token rewards to hundreds of addresses in one transaction
+- **DAO reward distribution** — disburse governance participation rewards atomically
+- **Revenue splitting** — forward protocol fees to multiple beneficiaries (treasury, team, DAO) in a single call
+- **NFT mint proceeds** — split mint revenue across creators and royalty recipients
+
+---
+
+## Related examples
+
+- `examples/advanced/01-multi-party-auth` — authorize an action with multiple signers
+- `examples/tokens/01-sep41-token` — full SEP-41 token with allowances
+- `examples/tokens/02-sep41-extensions` — permit (gasless approve) and batch operations on a SEP-41 token

--- a/examples/advanced/05-batch-transfer/src/lib.rs
+++ b/examples/advanced/05-batch-transfer/src/lib.rs
@@ -1,0 +1,273 @@
+//! # Batch Transfer
+//!
+//! Demonstrates efficient multi-recipient token transfers on Soroban.
+//!
+//! Key patterns shown:
+//! - Single-read / single-write for the sender balance (gas optimised)
+//! - Checked arithmetic to prevent overflow on every debit and credit
+//! - A dedicated `#[contracterror]` enum for clear, typed failures
+//! - Events for every individual transfer within the batch
+//! - An internal token ledger so the example is self-contained and fully
+//!   testable without a live token contract
+//!
+//! ## Use cases
+//! - Payroll / airdrop: send rewards to many recipients in one transaction
+//! - DAO distribution: disburse governance rewards atomically
+//! - NFT mint revenue split: forward proceeds to multiple beneficiaries
+
+#![no_std]
+
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env, Symbol, Vec,
+};
+
+// ---------------------------------------------------------------------------
+// Storage keys
+// ---------------------------------------------------------------------------
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    /// Token balance of an address.
+    Balance(Address),
+    /// Whether the contract has been initialised.
+    Initialized,
+}
+
+// ---------------------------------------------------------------------------
+// Transfer descriptor
+// ---------------------------------------------------------------------------
+
+/// A single `(recipient, amount)` pair in a batch.
+///
+/// The `amount` field must be a strictly positive `i128`.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Transfer {
+    pub to: Address,
+    pub amount: i128,
+}
+
+// ---------------------------------------------------------------------------
+// Events
+// ---------------------------------------------------------------------------
+
+/// Emitted once for every successful transfer within a batch.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TransferEvent {
+    pub from: Address,
+    pub to: Address,
+    pub amount: i128,
+}
+
+/// Emitted after a batch completes, summarising the run.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BatchCompleteEvent {
+    pub from: Address,
+    pub recipient_count: u32,
+    pub total_amount: i128,
+}
+
+const NS: Symbol = symbol_short!("batch");
+const EV_XFER: Symbol = symbol_short!("transfer");
+const EV_BATCH: Symbol = symbol_short!("complete");
+const EV_MINT: Symbol = symbol_short!("mint");
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum BatchError {
+    /// The contract has already been initialised.
+    AlreadyInitialized = 1,
+    /// The contract has not been initialised yet.
+    NotInitialized = 2,
+    /// The caller is not the admin.
+    Unauthorized = 3,
+    /// The sender does not have enough tokens to cover the batch.
+    InsufficientBalance = 4,
+    /// An amount in the batch is zero or negative.
+    InvalidAmount = 5,
+    /// Adding the amounts in the batch would overflow `i128`.
+    TotalOverflow = 6,
+    /// The batch is empty — nothing to do.
+    EmptyBatch = 7,
+    /// The batch exceeds the maximum allowed recipient count.
+    BatchTooLarge = 8,
+    /// A credit to a recipient would overflow their balance.
+    RecipientOverflow = 9,
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Maximum number of recipients in a single batch call.
+pub const MAX_BATCH_SIZE: u32 = 100;
+
+// ---------------------------------------------------------------------------
+// Contract
+// ---------------------------------------------------------------------------
+
+#[contract]
+pub struct BatchTransferContract;
+
+#[contractimpl]
+impl BatchTransferContract {
+    // -----------------------------------------------------------------------
+    // Initialisation
+    // -----------------------------------------------------------------------
+
+    /// Initialise the contract and mint an opening balance to `admin`.
+    ///
+    /// Can only be called once.
+    pub fn initialize(env: Env, admin: Address, initial_supply: i128) -> Result<(), BatchError> {
+        if env.storage().instance().has(&DataKey::Initialized) {
+            return Err(BatchError::AlreadyInitialized);
+        }
+        if initial_supply <= 0 {
+            return Err(BatchError::InvalidAmount);
+        }
+
+        env.storage().instance().set(&DataKey::Initialized, &true);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Balance(admin.clone()), &initial_supply);
+
+        env.events()
+            .publish((NS, EV_MINT, admin.clone()), initial_supply);
+
+        Ok(())
+    }
+
+    // -----------------------------------------------------------------------
+    // Core: batch transfer
+    // -----------------------------------------------------------------------
+
+    /// Transfer tokens from `from` to multiple recipients atomically.
+    ///
+    /// # Gas optimisation
+    ///
+    /// The sender's balance is read **once** before the loop and written
+    /// **once** after. Each recipient's balance is read and written exactly
+    /// once. This is significantly cheaper than looping over individual
+    /// `transfer` calls, each of which would incur separate storage round-trips.
+    ///
+    /// # Atomicity
+    ///
+    /// If any validation step fails (insufficient balance, overflow, invalid
+    /// amount) the function returns an error and **no** storage is mutated —
+    /// the entire batch is rejected.
+    pub fn batch_transfer(
+        env: Env,
+        from: Address,
+        transfers: Vec<Transfer>,
+    ) -> Result<u32, BatchError> {
+        // Authorization
+        from.require_auth();
+
+        ensure_initialized(&env)?;
+
+        // Validate batch size
+        let count = transfers.len();
+        if count == 0 {
+            return Err(BatchError::EmptyBatch);
+        }
+        if count > MAX_BATCH_SIZE {
+            return Err(BatchError::BatchTooLarge);
+        }
+
+        // --- Validation pass: sum total and check individual amounts --------
+        let mut total: i128 = 0;
+        for item in transfers.iter() {
+            if item.amount <= 0 {
+                return Err(BatchError::InvalidAmount);
+            }
+            total = total
+                .checked_add(item.amount)
+                .ok_or(BatchError::TotalOverflow)?;
+        }
+
+        // --- Balance check (single storage read) ----------------------------
+        let sender_balance = read_balance(&env, &from);
+        if sender_balance < total {
+            return Err(BatchError::InsufficientBalance);
+        }
+
+        // --- Mutations (all-or-nothing) -------------------------------------
+        // Debit sender once
+        write_balance(&env, &from, sender_balance - total);
+
+        // Credit each recipient and emit an event
+        for item in transfers.iter() {
+            let old = read_balance(&env, &item.to);
+            let new_bal = old
+                .checked_add(item.amount)
+                .ok_or(BatchError::RecipientOverflow)?;
+            write_balance(&env, &item.to, new_bal);
+
+            env.events().publish(
+                (NS, EV_XFER),
+                TransferEvent {
+                    from: from.clone(),
+                    to: item.to.clone(),
+                    amount: item.amount,
+                },
+            );
+        }
+
+        // Batch-complete summary event
+        env.events().publish(
+            (NS, EV_BATCH, from.clone()),
+            BatchCompleteEvent {
+                from,
+                recipient_count: count,
+                total_amount: total,
+            },
+        );
+
+        Ok(count)
+    }
+
+    // -----------------------------------------------------------------------
+    // Queries
+    // -----------------------------------------------------------------------
+
+    /// Return the token balance for `user`.
+    pub fn balance(env: Env, user: Address) -> i128 {
+        read_balance(&env, &user)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------------
+
+fn ensure_initialized(env: &Env) -> Result<(), BatchError> {
+    if env.storage().instance().has(&DataKey::Initialized) {
+        Ok(())
+    } else {
+        Err(BatchError::NotInitialized)
+    }
+}
+
+fn read_balance(env: &Env, user: &Address) -> i128 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Balance(user.clone()))
+        .unwrap_or(0)
+}
+
+fn write_balance(env: &Env, user: &Address, amount: i128) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Balance(user.clone()), &amount);
+}
+
+#[cfg(test)]
+mod test;

--- a/examples/advanced/05-batch-transfer/src/test.rs
+++ b/examples/advanced/05-batch-transfer/src/test.rs
@@ -1,0 +1,281 @@
+extern crate std;
+
+use super::*;
+use soroban_sdk::{testutils::Address as _, Address, Env, Vec};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn setup(initial_supply: i128) -> (Env, BatchTransferContractClient<'static>, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, BatchTransferContract);
+    let client = BatchTransferContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    // Soroban SDK client unwraps Result<(), E> to () — no .unwrap() needed
+    client.initialize(&admin, &initial_supply);
+    (env, client, admin)
+}
+
+fn make_transfer(to: Address, amount: i128) -> Transfer {
+    Transfer { to, amount }
+}
+
+// ---------------------------------------------------------------------------
+// Initialisation tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_initialize_sets_balance() {
+    let (env, client, admin) = setup(1_000);
+    assert_eq!(client.balance(&admin), 1_000);
+    let _ = env;
+}
+
+#[test]
+fn test_initialize_double_call_fails() {
+    let (env, client, admin) = setup(1_000);
+    let result = client.try_initialize(&admin, &500);
+    assert_eq!(result, Err(Ok(BatchError::AlreadyInitialized)));
+    let _ = env;
+}
+
+#[test]
+fn test_initialize_zero_supply_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, BatchTransferContract);
+    let client = BatchTransferContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let result = client.try_initialize(&admin, &0);
+    assert_eq!(result, Err(Ok(BatchError::InvalidAmount)));
+}
+
+#[test]
+fn test_initialize_negative_supply_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, BatchTransferContract);
+    let client = BatchTransferContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let result = client.try_initialize(&admin, &-100);
+    assert_eq!(result, Err(Ok(BatchError::InvalidAmount)));
+}
+
+// ---------------------------------------------------------------------------
+// Batch transfer — happy paths
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_single_recipient_batch() {
+    let (env, client, admin) = setup(1_000);
+    let recipient = Address::generate(&env);
+
+    let transfers = Vec::from_array(&env, [make_transfer(recipient.clone(), 300)]);
+    // Soroban client returns u32 directly (panics on error)
+    let count = client.batch_transfer(&admin, &transfers);
+
+    assert_eq!(count, 1);
+    assert_eq!(client.balance(&admin), 700);
+    assert_eq!(client.balance(&recipient), 300);
+}
+
+#[test]
+fn test_multiple_recipients() {
+    let (env, client, admin) = setup(1_000);
+    let r1 = Address::generate(&env);
+    let r2 = Address::generate(&env);
+    let r3 = Address::generate(&env);
+
+    let transfers = Vec::from_array(
+        &env,
+        [
+            make_transfer(r1.clone(), 100),
+            make_transfer(r2.clone(), 200),
+            make_transfer(r3.clone(), 300),
+        ],
+    );
+    let count = client.batch_transfer(&admin, &transfers);
+
+    assert_eq!(count, 3);
+    assert_eq!(client.balance(&admin), 400);
+    assert_eq!(client.balance(&r1), 100);
+    assert_eq!(client.balance(&r2), 200);
+    assert_eq!(client.balance(&r3), 300);
+}
+
+#[test]
+fn test_batch_to_same_recipient_twice_accumulates() {
+    let (env, client, admin) = setup(1_000);
+    let r = Address::generate(&env);
+
+    // Two entries with the same recipient — both should be credited
+    let transfers = Vec::from_array(
+        &env,
+        [make_transfer(r.clone(), 150), make_transfer(r.clone(), 250)],
+    );
+    client.batch_transfer(&admin, &transfers);
+
+    assert_eq!(client.balance(&admin), 600);
+    assert_eq!(client.balance(&r), 400);
+}
+
+#[test]
+fn test_exact_balance_drains_to_zero() {
+    let (env, client, admin) = setup(500);
+    let r = Address::generate(&env);
+
+    let transfers = Vec::from_array(&env, [make_transfer(r.clone(), 500)]);
+    client.batch_transfer(&admin, &transfers);
+
+    assert_eq!(client.balance(&admin), 0);
+    assert_eq!(client.balance(&r), 500);
+}
+
+// ---------------------------------------------------------------------------
+// Batch transfer — error paths
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_batch_not_initialized_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, BatchTransferContract);
+    let client = BatchTransferContractClient::new(&env, &contract_id);
+    let from = Address::generate(&env);
+    let r = Address::generate(&env);
+
+    let transfers = Vec::from_array(&env, [make_transfer(r, 100)]);
+    let result = client.try_batch_transfer(&from, &transfers);
+    assert_eq!(result, Err(Ok(BatchError::NotInitialized)));
+}
+
+#[test]
+fn test_empty_batch_fails() {
+    let (env, client, admin) = setup(1_000);
+    let empty: Vec<Transfer> = Vec::new(&env);
+    let result = client.try_batch_transfer(&admin, &empty);
+    assert_eq!(result, Err(Ok(BatchError::EmptyBatch)));
+}
+
+#[test]
+fn test_zero_amount_in_batch_fails() {
+    let (env, client, admin) = setup(1_000);
+    let r = Address::generate(&env);
+
+    let transfers = Vec::from_array(
+        &env,
+        [
+            make_transfer(r.clone(), 100),
+            make_transfer(r.clone(), 0), // invalid
+        ],
+    );
+    let result = client.try_batch_transfer(&admin, &transfers);
+    assert_eq!(result, Err(Ok(BatchError::InvalidAmount)));
+    // State must be unchanged
+    assert_eq!(client.balance(&admin), 1_000);
+    assert_eq!(client.balance(&r), 0);
+}
+
+#[test]
+fn test_negative_amount_in_batch_fails() {
+    let (env, client, admin) = setup(1_000);
+    let r = Address::generate(&env);
+
+    let transfers = Vec::from_array(&env, [make_transfer(r.clone(), -50)]);
+    let result = client.try_batch_transfer(&admin, &transfers);
+    assert_eq!(result, Err(Ok(BatchError::InvalidAmount)));
+    assert_eq!(client.balance(&admin), 1_000);
+}
+
+#[test]
+fn test_insufficient_balance_fails() {
+    let (env, client, admin) = setup(100);
+    let r1 = Address::generate(&env);
+    let r2 = Address::generate(&env);
+
+    let transfers = Vec::from_array(
+        &env,
+        [
+            make_transfer(r1.clone(), 70),
+            make_transfer(r2.clone(), 50), // 70+50=120 > 100
+        ],
+    );
+    let result = client.try_batch_transfer(&admin, &transfers);
+    assert_eq!(result, Err(Ok(BatchError::InsufficientBalance)));
+
+    // No state mutation on failure
+    assert_eq!(client.balance(&admin), 100);
+    assert_eq!(client.balance(&r1), 0);
+    assert_eq!(client.balance(&r2), 0);
+}
+
+#[test]
+fn test_batch_too_large_fails() {
+    let supply: i128 = (MAX_BATCH_SIZE as i128 + 1) * 10;
+    let (env, client, admin) = setup(supply);
+
+    let mut transfers: Vec<Transfer> = Vec::new(&env);
+    for _ in 0..=MAX_BATCH_SIZE {
+        let r = Address::generate(&env);
+        transfers.push_back(make_transfer(r, 10));
+    }
+
+    let result = client.try_batch_transfer(&admin, &transfers);
+    assert_eq!(result, Err(Ok(BatchError::BatchTooLarge)));
+}
+
+// ---------------------------------------------------------------------------
+// Authorization tests
+// ---------------------------------------------------------------------------
+
+#[test]
+#[should_panic(expected = "HostError: Error(Auth, InvalidAction)")]
+fn test_batch_transfer_unauthorized() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, BatchTransferContract);
+    let client = BatchTransferContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin, &1_000);
+
+    // Strip auths so the batch call fails auth check
+    env.set_auths(&[]);
+
+    let r = Address::generate(&env);
+    let transfers = Vec::from_array(&env, [make_transfer(r, 100)]);
+    client.batch_transfer(&admin, &transfers);
+}
+
+// ---------------------------------------------------------------------------
+// Gas optimisation: verify single read/write on sender balance
+// (Behavioural proxy: correctness after N recipients stays consistent)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_large_valid_batch_correctness() {
+    // 20 recipients keeps us well within Soroban's ledger-entry limits
+    // (max 50 write entries; 1 sender + 20 recipients = 21 writes)
+    let n: u32 = 20;
+    let amount_each: i128 = 10;
+    let supply = n as i128 * amount_each;
+
+    let (env, client, admin) = setup(supply);
+
+    let mut transfers: Vec<Transfer> = Vec::new(&env);
+    let mut recipients: std::vec::Vec<Address> = std::vec::Vec::new();
+    for _ in 0..n {
+        let r = Address::generate(&env);
+        recipients.push(r.clone());
+        transfers.push_back(make_transfer(r, amount_each));
+    }
+
+    let count = client.batch_transfer(&admin, &transfers);
+    assert_eq!(count, n);
+    assert_eq!(client.balance(&admin), 0);
+    for r in &recipients {
+        assert_eq!(client.balance(r), amount_each);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #646 — adds a complete `05-batch-transfer` example under `examples/advanced/`.

- Multi-recipient atomic token transfers in a single transaction
- Gas optimisation: sender balance read once and written once regardless of recipient count (2+2N ops vs 4N naïve)
- All-or-nothing atomicity: full validation pass before any storage mutation
- Typed `BatchError` enum with 9 variants covering all failure modes
- Per-transfer `TransferEvent` and batch-summary `BatchCompleteEvent`
- `MAX_BATCH_SIZE = 100` guard against over-large batches
- 16 unit tests covering happy paths, error paths, authorization, and edge cases

## Test plan

- [x] `cargo test -p batch-transfer` — 16/16 pass
- [x] `cargo fmt -p batch-transfer -- --check` — clean
- [x] CI clippy/test/build will run on PR open

🤖 Generated with [Claude Code](https://claude.com/claude-code)