### PR TITLE
feat(tokens): add 02-sep41-extensions example

### DIFF
--- a/examples/advanced/05-batch-transfer/Cargo.toml
+++ b/examples/advanced/05-batch-transfer/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "batch-transfer"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = { workspace = true, features = ["alloc"] }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils", "alloc"] }

--- a/examples/advanced/05-batch-transfer/README.md
+++ b/examples/advanced/05-batch-transfer/README.md
@@ -1,0 +1,113 @@
+# 05 — Batch Transfer
+
+Send tokens to multiple recipients in a single, atomic Soroban transaction.
+
+---
+
+## What it does
+
+The `BatchTransferContract` lets a sender transfer different amounts to up to **100 recipients** in one invocation. Because the sender's balance is read once and written once (rather than once per recipient), batch transfers are significantly cheaper on-chain than looping over individual `transfer` calls.
+
+If any validation check fails — empty batch, invalid amount, or insufficient balance — **the entire batch is rejected** and no state is mutated.
+
+---
+
+## Key concepts
+
+| Concept | Where |
+|---------|-------|
+| Single-read / single-write gas optimisation | `batch_transfer` in `src/lib.rs` |
+| Checked arithmetic on totals and per-recipient credits | `checked_add` calls in `batch_transfer` |
+| Atomic all-or-nothing execution | Validation pass before any storage write |
+| `#[contracterror]` enum with typed failures | `BatchError` in `src/lib.rs` |
+| Event per transfer + batch-complete summary event | `TransferEvent`, `BatchCompleteEvent` |
+| `#[contracttype]` for transfer descriptors | `Transfer` struct |
+
+---
+
+## Contract API
+
+### `initialize(admin: Address, initial_supply: i128) → Result<(), BatchError>`
+
+One-time setup. Mints `initial_supply` tokens to `admin`.
+
+Errors: `AlreadyInitialized`, `InvalidAmount`
+
+---
+
+### `batch_transfer(from: Address, transfers: Vec<Transfer>) → Result<u32, BatchError>`
+
+Transfer tokens from `from` to all recipients described in `transfers`.
+
+`from` must authorize the call. Returns the number of recipients credited.
+
+**`Transfer` struct:**
+
+```rust
+pub struct Transfer {
+    pub to: Address,   // recipient
+    pub amount: i128,  // must be > 0
+}
+```
+
+**Error table:**
+
+| Error | Condition |
+|-------|-----------|
+| `NotInitialized` | Contract not yet initialized |
+| `EmptyBatch` | `transfers` is empty |
+| `BatchTooLarge` | More than `MAX_BATCH_SIZE` (100) entries |
+| `InvalidAmount` | Any `amount` ≤ 0 |
+| `TotalOverflow` | Sum of all amounts overflows `i128` |
+| `InsufficientBalance` | Sender balance < total |
+| `RecipientOverflow` | A recipient's new balance would overflow `i128` |
+
+---
+
+### `balance(user: Address) → i128`
+
+Returns the current token balance for `user`.
+
+---
+
+## Gas optimisation explained
+
+A naïve implementation of multi-recipient transfers loops and calls a `transfer` function per recipient. Each call reads and writes the sender's balance. For N recipients that is 2N storage operations on the sender's balance alone.
+
+This example reads the sender's balance **once**, validates the full batch, then:
+1. Writes the sender's new balance **once** (deducting the total)
+2. Reads and writes each recipient's balance exactly once
+
+Total storage ops = `1 read + 1 write` (sender) + `N reads + N writes` (recipients) = `2 + 2N` instead of `2N + 2N = 4N` for naïve looping.
+
+---
+
+## How to build and test
+
+```bash
+# Run unit tests
+cargo test -p batch-transfer
+
+# Build WASM release binary
+cargo build --target wasm32-unknown-unknown --release -p batch-transfer
+
+# Lint
+cargo clippy -p batch-transfer --all-targets -- -D warnings
+```
+
+---
+
+## Use cases
+
+- **Payroll / airdrop** — distribute stablecoin salaries or token rewards to hundreds of addresses in one transaction
+- **DAO reward distribution** — disburse governance participation rewards atomically
+- **Revenue splitting** — forward protocol fees to multiple beneficiaries (treasury, team, DAO) in a single call
+- **NFT mint proceeds** — split mint revenue across creators and royalty recipients
+
+---
+
+## Related examples
+
+- `examples/advanced/01-multi-party-auth` — authorize an action with multiple signers
+- `examples/tokens/01-sep41-token` — full SEP-41 token with allowances
+- `examples/tokens/02-sep41-extensions` — permit (gasless approve) and batch operations on a SEP-41 token

--- a/examples/advanced/05-batch-transfer/src/lib.rs
+++ b/examples/advanced/05-batch-transfer/src/lib.rs
@@ -1,0 +1,273 @@
+//! # Batch Transfer
+//!
+//! Demonstrates efficient multi-recipient token transfers on Soroban.
+//!
+//! Key patterns shown:
+//! - Single-read / single-write for the sender balance (gas optimised)
+//! - Checked arithmetic to prevent overflow on every debit and credit
+//! - A dedicated `#[contracterror]` enum for clear, typed failures
+//! - Events for every individual transfer within the batch
+//! - An internal token ledger so the example is self-contained and fully
+//!   testable without a live token contract
+//!
+//! ## Use cases
+//! - Payroll / airdrop: send rewards to many recipients in one transaction
+//! - DAO distribution: disburse governance rewards atomically
+//! - NFT mint revenue split: forward proceeds to multiple beneficiaries
+
+#![no_std]
+
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env, Symbol, Vec,
+};
+
+// ---------------------------------------------------------------------------
+// Storage keys
+// ---------------------------------------------------------------------------
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    /// Token balance of an address.
+    Balance(Address),
+    /// Whether the contract has been initialised.
+    Initialized,
+}
+
+// ---------------------------------------------------------------------------
+// Transfer descriptor
+// ---------------------------------------------------------------------------
+
+/// A single `(recipient, amount)` pair in a batch.
+///
+/// The `amount` field must be a strictly positive `i128`.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Transfer {
+    pub to: Address,
+    pub amount: i128,
+}
+
+// ---------------------------------------------------------------------------
+// Events
+// ---------------------------------------------------------------------------
+
+/// Emitted once for every successful transfer within a batch.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TransferEvent {
+    pub from: Address,
+    pub to: Address,
+    pub amount: i128,
+}
+
+/// Emitted after a batch completes, summarising the run.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BatchCompleteEvent {
+    pub from: Address,
+    pub recipient_count: u32,
+    pub total_amount: i128,
+}
+
+const NS: Symbol = symbol_short!("batch");
+const EV_XFER: Symbol = symbol_short!("transfer");
+const EV_BATCH: Symbol = symbol_short!("complete");
+const EV_MINT: Symbol = symbol_short!("mint");
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum BatchError {
+    /// The contract has already been initialised.
+    AlreadyInitialized = 1,
+    /// The contract has not been initialised yet.
+    NotInitialized = 2,
+    /// The caller is not the admin.
+    Unauthorized = 3,
+    /// The sender does not have enough tokens to cover the batch.
+    InsufficientBalance = 4,
+    /// An amount in the batch is zero or negative.
+    InvalidAmount = 5,
+    /// Adding the amounts in the batch would overflow `i128`.
+    TotalOverflow = 6,
+    /// The batch is empty — nothing to do.
+    EmptyBatch = 7,
+    /// The batch exceeds the maximum allowed recipient count.
+    BatchTooLarge = 8,
+    /// A credit to a recipient would overflow their balance.
+    RecipientOverflow = 9,
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Maximum number of recipients in a single batch call.
+pub const MAX_BATCH_SIZE: u32 = 100;
+
+// ---------------------------------------------------------------------------
+// Contract
+// ---------------------------------------------------------------------------
+
+#[contract]
+pub struct BatchTransferContract;
+
+#[contractimpl]
+impl BatchTransferContract {
+    // -----------------------------------------------------------------------
+    // Initialisation
+    // -----------------------------------------------------------------------
+
+    /// Initialise the contract and mint an opening balance to `admin`.
+    ///
+    /// Can only be called once.
+    pub fn initialize(env: Env, admin: Address, initial_supply: i128) -> Result<(), BatchError> {
+        if env.storage().instance().has(&DataKey::Initialized) {
+            return Err(BatchError::AlreadyInitialized);
+        }
+        if initial_supply <= 0 {
+            return Err(BatchError::InvalidAmount);
+        }
+
+        env.storage().instance().set(&DataKey::Initialized, &true);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Balance(admin.clone()), &initial_supply);
+
+        env.events()
+            .publish((NS, EV_MINT, admin.clone()), initial_supply);
+
+        Ok(())
+    }
+
+    // -----------------------------------------------------------------------
+    // Core: batch transfer
+    // -----------------------------------------------------------------------
+
+    /// Transfer tokens from `from` to multiple recipients atomically.
+    ///
+    /// # Gas optimisation
+    ///
+    /// The sender's balance is read **once** before the loop and written
+    /// **once** after. Each recipient's balance is read and written exactly
+    /// once. This is significantly cheaper than looping over individual
+    /// `transfer` calls, each of which would incur separate storage round-trips.
+    ///
+    /// # Atomicity
+    ///
+    /// If any validation step fails (insufficient balance, overflow, invalid
+    /// amount) the function returns an error and **no** storage is mutated —
+    /// the entire batch is rejected.
+    pub fn batch_transfer(
+        env: Env,
+        from: Address,
+        transfers: Vec<Transfer>,
+    ) -> Result<u32, BatchError> {
+        // Authorization
+        from.require_auth();
+
+        ensure_initialized(&env)?;
+
+        // Validate batch size
+        let count = transfers.len();
+        if count == 0 {
+            return Err(BatchError::EmptyBatch);
+        }
+        if count > MAX_BATCH_SIZE {
+            return Err(BatchError::BatchTooLarge);
+        }
+
+        // --- Validation pass: sum total and check individual amounts --------
+        let mut total: i128 = 0;
+        for item in transfers.iter() {
+            if item.amount <= 0 {
+                return Err(BatchError::InvalidAmount);
+            }
+            total = total
+                .checked_add(item.amount)
+                .ok_or(BatchError::TotalOverflow)?;
+        }
+
+        // --- Balance check (single storage read) ----------------------------
+        let sender_balance = read_balance(&env, &from);
+        if sender_balance < total {
+            return Err(BatchError::InsufficientBalance);
+        }
+
+        // --- Mutations (all-or-nothing) -------------------------------------
+        // Debit sender once
+        write_balance(&env, &from, sender_balance - total);
+
+        // Credit each recipient and emit an event
+        for item in transfers.iter() {
+            let old = read_balance(&env, &item.to);
+            let new_bal = old
+                .checked_add(item.amount)
+                .ok_or(BatchError::RecipientOverflow)?;
+            write_balance(&env, &item.to, new_bal);
+
+            env.events().publish(
+                (NS, EV_XFER),
+                TransferEvent {
+                    from: from.clone(),
+                    to: item.to.clone(),
+                    amount: item.amount,
+                },
+            );
+        }
+
+        // Batch-complete summary event
+        env.events().publish(
+            (NS, EV_BATCH, from.clone()),
+            BatchCompleteEvent {
+                from,
+                recipient_count: count,
+                total_amount: total,
+            },
+        );
+
+        Ok(count)
+    }
+
+    // -----------------------------------------------------------------------
+    // Queries
+    // -----------------------------------------------------------------------
+
+    /// Return the token balance for `user`.
+    pub fn balance(env: Env, user: Address) -> i128 {
+        read_balance(&env, &user)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------------
+
+fn ensure_initialized(env: &Env) -> Result<(), BatchError> {
+    if env.storage().instance().has(&DataKey::Initialized) {
+        Ok(())
+    } else {
+        Err(BatchError::NotInitialized)
+    }
+}
+
+fn read_balance(env: &Env, user: &Address) -> i128 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Balance(user.clone()))
+        .unwrap_or(0)
+}
+
+fn write_balance(env: &Env, user: &Address, amount: i128) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Balance(user.clone()), &amount);
+}
+
+#[cfg(test)]
+mod test;

--- a/examples/advanced/05-batch-transfer/src/test.rs
+++ b/examples/advanced/05-batch-transfer/src/test.rs
@@ -1,0 +1,281 @@
+extern crate std;
+
+use super::*;
+use soroban_sdk::{testutils::Address as _, Address, Env, Vec};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn setup(initial_supply: i128) -> (Env, BatchTransferContractClient<'static>, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, BatchTransferContract);
+    let client = BatchTransferContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    // Soroban SDK client unwraps Result<(), E> to () — no .unwrap() needed
+    client.initialize(&admin, &initial_supply);
+    (env, client, admin)
+}
+
+fn make_transfer(to: Address, amount: i128) -> Transfer {
+    Transfer { to, amount }
+}
+
+// ---------------------------------------------------------------------------
+// Initialisation tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_initialize_sets_balance() {
+    let (env, client, admin) = setup(1_000);
+    assert_eq!(client.balance(&admin), 1_000);
+    let _ = env;
+}
+
+#[test]
+fn test_initialize_double_call_fails() {
+    let (env, client, admin) = setup(1_000);
+    let result = client.try_initialize(&admin, &500);
+    assert_eq!(result, Err(Ok(BatchError::AlreadyInitialized)));
+    let _ = env;
+}
+
+#[test]
+fn test_initialize_zero_supply_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, BatchTransferContract);
+    let client = BatchTransferContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let result = client.try_initialize(&admin, &0);
+    assert_eq!(result, Err(Ok(BatchError::InvalidAmount)));
+}
+
+#[test]
+fn test_initialize_negative_supply_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, BatchTransferContract);
+    let client = BatchTransferContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let result = client.try_initialize(&admin, &-100);
+    assert_eq!(result, Err(Ok(BatchError::InvalidAmount)));
+}
+
+// ---------------------------------------------------------------------------
+// Batch transfer — happy paths
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_single_recipient_batch() {
+    let (env, client, admin) = setup(1_000);
+    let recipient = Address::generate(&env);
+
+    let transfers = Vec::from_array(&env, [make_transfer(recipient.clone(), 300)]);
+    // Soroban client returns u32 directly (panics on error)
+    let count = client.batch_transfer(&admin, &transfers);
+
+    assert_eq!(count, 1);
+    assert_eq!(client.balance(&admin), 700);
+    assert_eq!(client.balance(&recipient), 300);
+}
+
+#[test]
+fn test_multiple_recipients() {
+    let (env, client, admin) = setup(1_000);
+    let r1 = Address::generate(&env);
+    let r2 = Address::generate(&env);
+    let r3 = Address::generate(&env);
+
+    let transfers = Vec::from_array(
+        &env,
+        [
+            make_transfer(r1.clone(), 100),
+            make_transfer(r2.clone(), 200),
+            make_transfer(r3.clone(), 300),
+        ],
+    );
+    let count = client.batch_transfer(&admin, &transfers);
+
+    assert_eq!(count, 3);
+    assert_eq!(client.balance(&admin), 400);
+    assert_eq!(client.balance(&r1), 100);
+    assert_eq!(client.balance(&r2), 200);
+    assert_eq!(client.balance(&r3), 300);
+}
+
+#[test]
+fn test_batch_to_same_recipient_twice_accumulates() {
+    let (env, client, admin) = setup(1_000);
+    let r = Address::generate(&env);
+
+    // Two entries with the same recipient — both should be credited
+    let transfers = Vec::from_array(
+        &env,
+        [make_transfer(r.clone(), 150), make_transfer(r.clone(), 250)],
+    );
+    client.batch_transfer(&admin, &transfers);
+
+    assert_eq!(client.balance(&admin), 600);
+    assert_eq!(client.balance(&r), 400);
+}
+
+#[test]
+fn test_exact_balance_drains_to_zero() {
+    let (env, client, admin) = setup(500);
+    let r = Address::generate(&env);
+
+    let transfers = Vec::from_array(&env, [make_transfer(r.clone(), 500)]);
+    client.batch_transfer(&admin, &transfers);
+
+    assert_eq!(client.balance(&admin), 0);
+    assert_eq!(client.balance(&r), 500);
+}
+
+// ---------------------------------------------------------------------------
+// Batch transfer — error paths
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_batch_not_initialized_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, BatchTransferContract);
+    let client = BatchTransferContractClient::new(&env, &contract_id);
+    let from = Address::generate(&env);
+    let r = Address::generate(&env);
+
+    let transfers = Vec::from_array(&env, [make_transfer(r, 100)]);
+    let result = client.try_batch_transfer(&from, &transfers);
+    assert_eq!(result, Err(Ok(BatchError::NotInitialized)));
+}
+
+#[test]
+fn test_empty_batch_fails() {
+    let (env, client, admin) = setup(1_000);
+    let empty: Vec<Transfer> = Vec::new(&env);
+    let result = client.try_batch_transfer(&admin, &empty);
+    assert_eq!(result, Err(Ok(BatchError::EmptyBatch)));
+}
+
+#[test]
+fn test_zero_amount_in_batch_fails() {
+    let (env, client, admin) = setup(1_000);
+    let r = Address::generate(&env);
+
+    let transfers = Vec::from_array(
+        &env,
+        [
+            make_transfer(r.clone(), 100),
+            make_transfer(r.clone(), 0), // invalid
+        ],
+    );
+    let result = client.try_batch_transfer(&admin, &transfers);
+    assert_eq!(result, Err(Ok(BatchError::InvalidAmount)));
+    // State must be unchanged
+    assert_eq!(client.balance(&admin), 1_000);
+    assert_eq!(client.balance(&r), 0);
+}
+
+#[test]
+fn test_negative_amount_in_batch_fails() {
+    let (env, client, admin) = setup(1_000);
+    let r = Address::generate(&env);
+
+    let transfers = Vec::from_array(&env, [make_transfer(r.clone(), -50)]);
+    let result = client.try_batch_transfer(&admin, &transfers);
+    assert_eq!(result, Err(Ok(BatchError::InvalidAmount)));
+    assert_eq!(client.balance(&admin), 1_000);
+}
+
+#[test]
+fn test_insufficient_balance_fails() {
+    let (env, client, admin) = setup(100);
+    let r1 = Address::generate(&env);
+    let r2 = Address::generate(&env);
+
+    let transfers = Vec::from_array(
+        &env,
+        [
+            make_transfer(r1.clone(), 70),
+            make_transfer(r2.clone(), 50), // 70+50=120 > 100
+        ],
+    );
+    let result = client.try_batch_transfer(&admin, &transfers);
+    assert_eq!(result, Err(Ok(BatchError::InsufficientBalance)));
+
+    // No state mutation on failure
+    assert_eq!(client.balance(&admin), 100);
+    assert_eq!(client.balance(&r1), 0);
+    assert_eq!(client.balance(&r2), 0);
+}
+
+#[test]
+fn test_batch_too_large_fails() {
+    let supply: i128 = (MAX_BATCH_SIZE as i128 + 1) * 10;
+    let (env, client, admin) = setup(supply);
+
+    let mut transfers: Vec<Transfer> = Vec::new(&env);
+    for _ in 0..=MAX_BATCH_SIZE {
+        let r = Address::generate(&env);
+        transfers.push_back(make_transfer(r, 10));
+    }
+
+    let result = client.try_batch_transfer(&admin, &transfers);
+    assert_eq!(result, Err(Ok(BatchError::BatchTooLarge)));
+}
+
+// ---------------------------------------------------------------------------
+// Authorization tests
+// ---------------------------------------------------------------------------
+
+#[test]
+#[should_panic(expected = "HostError: Error(Auth, InvalidAction)")]
+fn test_batch_transfer_unauthorized() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, BatchTransferContract);
+    let client = BatchTransferContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin, &1_000);
+
+    // Strip auths so the batch call fails auth check
+    env.set_auths(&[]);
+
+    let r = Address::generate(&env);
+    let transfers = Vec::from_array(&env, [make_transfer(r, 100)]);
+    client.batch_transfer(&admin, &transfers);
+}
+
+// ---------------------------------------------------------------------------
+// Gas optimisation: verify single read/write on sender balance
+// (Behavioural proxy: correctness after N recipients stays consistent)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_large_valid_batch_correctness() {
+    // 20 recipients keeps us well within Soroban's ledger-entry limits
+    // (max 50 write entries; 1 sender + 20 recipients = 21 writes)
+    let n: u32 = 20;
+    let amount_each: i128 = 10;
+    let supply = n as i128 * amount_each;
+
+    let (env, client, admin) = setup(supply);
+
+    let mut transfers: Vec<Transfer> = Vec::new(&env);
+    let mut recipients: std::vec::Vec<Address> = std::vec::Vec::new();
+    for _ in 0..n {
+        let r = Address::generate(&env);
+        recipients.push(r.clone());
+        transfers.push_back(make_transfer(r, amount_each));
+    }
+
+    let count = client.batch_transfer(&admin, &transfers);
+    assert_eq!(count, n);
+    assert_eq!(client.balance(&admin), 0);
+    for r in &recipients {
+        assert_eq!(client.balance(r), amount_each);
+    }
+}

--- a/examples/tokens/02-sep41-extensions/Cargo.toml
+++ b/examples/tokens/02-sep41-extensions/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "sep41-extensions"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = { workspace = true, features = ["alloc"] }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils", "alloc"] }

--- a/examples/tokens/02-sep41-extensions/README.md
+++ b/examples/tokens/02-sep41-extensions/README.md
@@ -1,0 +1,165 @@
+# 02 — SEP-41 Extensions
+
+Optional extensions to a standard SEP-41 token contract: **permit** (off-chain
+approval), **batch transfer**, and **batch approve**.
+
+---
+
+## What it does
+
+The `Sep41Extensions` contract layers three optional capabilities on top of a
+minimal SEP-41 token:
+
+| Extension | Function | Purpose |
+|-----------|----------|---------|
+| Permit | `permit(owner, spender, amount, expiration_ledger)` | Approve a spender using an off-chain signature instead of an on-chain `approve` call (EIP-2612 equivalent) |
+| Batch transfer | `batch_transfer(from, transfers)` | Send different amounts to multiple recipients in one atomic call |
+| Batch approve | `batch_approve(owner, approvals)` | Set multiple allowances atomically |
+
+---
+
+## Key concepts
+
+### Permit (EIP-2612 equivalent)
+
+In Ethereum, EIP-2612 allows a token holder to sign an off-chain message that
+grants a spender an allowance.  The spender (or a relayer) then submits a
+single on-chain transaction that both sets the allowance and executes the
+downstream action.
+
+Soroban achieves the same outcome via its built-in auth framework.  The owner
+signs an authorisation envelope off-chain (using their Stellar key).  The
+spender submits the `permit` invocation with that envelope attached.
+
+`require_auth_for_args` binds the authorisation to the exact
+`(spender, amount, expiration_ledger)` arguments, preventing replay with
+different parameters.
+
+### Batch transfer gas optimisation
+
+The sender's balance is read **once** and written **once** regardless of the
+number of recipients.  This halves the number of sender-side storage operations
+compared to looping over individual `transfer` calls.
+
+### Batch approve
+
+Multiple allowances are set in a single contract invocation, saving round-trip
+overhead.  Passing `amount = 0` for any spender revokes that allowance.
+
+---
+
+## Contract API
+
+### `initialize(admin: Address, initial_supply: i128) → Result<(), ExtError>`
+
+One-time setup: mints `initial_supply` to `admin`.
+
+---
+
+### `permit(owner, spender, amount, expiration_ledger) → Result<(), ExtError>`
+
+Grant `spender` an allowance of `amount` from `owner` via off-chain signature.
+Valid through and including `expiration_ledger`.  Passing `amount = 0` revokes
+the allowance.
+
+| Error | Condition |
+|-------|-----------|
+| `NotInitialized` | Contract not yet set up |
+| `InvalidAmount` | `amount < 0` |
+| `ExpiredPermit` | `amount > 0` and `expiration_ledger < current_ledger` |
+
+---
+
+### `batch_transfer(from, transfers: Vec<Transfer>) → Result<u32, ExtError>`
+
+Transfer tokens from `from` to all recipients in `transfers` atomically.
+Returns the number of recipients credited.
+
+```rust
+pub struct Transfer {
+    pub to: Address,
+    pub amount: i128,  // must be > 0
+}
+```
+
+| Error | Condition |
+|-------|-----------|
+| `EmptyBatch` | `transfers` is empty |
+| `InvalidAmount` | Any `amount ≤ 0` |
+| `InsufficientBalance` | Sender balance < sum of all amounts |
+| `ArithmeticOverflow` | Arithmetic overflow detected |
+
+---
+
+### `batch_approve(owner, approvals: Vec<Approval>) → Result<u32, ExtError>`
+
+Set multiple allowances for `owner` in one call. Returns the number of
+allowances written.
+
+```rust
+pub struct Approval {
+    pub spender: Address,
+    pub amount: i128,           // 0 to revoke; must be ≥ 0
+    pub expiration_ledger: u32, // last ledger the allowance is valid
+}
+```
+
+---
+
+### `transfer`, `approve`, `transfer_from`, `balance`, `allowance`
+
+Standard SEP-41 functions. `allowance` returns `0` for expired entries.
+
+---
+
+## Error table
+
+| Error | Code | Meaning |
+|-------|------|---------|
+| `AlreadyInitialized` | 1 | `initialize` called twice |
+| `NotInitialized` | 2 | Contract not yet set up |
+| `InvalidAmount` | 3 | Amount is zero, negative, or otherwise invalid |
+| `InsufficientBalance` | 4 | Sender has fewer tokens than required |
+| `InsufficientAllowance` | 5 | Spender's allowance too small |
+| `ArithmeticOverflow` | 6 | Overflow detected during arithmetic |
+| `EmptyBatch` | 7 | Batch list is empty |
+| `ExpiredPermit` | 8 | Permit's expiration ledger is in the past |
+
+---
+
+## How to build and test
+
+```bash
+# Run unit tests
+cargo test -p sep41-extensions
+
+# Build WASM release binary
+cargo build --target wasm32-unknown-unknown --release -p sep41-extensions
+
+# Lint
+cargo clippy -p sep41-extensions --all-targets -- -D warnings
+```
+
+---
+
+## Use cases
+
+- **Gasless approve flows** — a relayer calls `permit` bundled with
+  `transfer_from` in one transaction; the owner never submits a separate
+  approve
+- **Batch payroll** — fund many addresses in a single call without looping
+  on-chain
+- **Bulk DeFi allowances** — approve multiple protocols at once before entering
+  a complex multi-step position
+- **DAO reward distribution** — set allowances for multiple recipients
+  atomically, then let each recipient pull their own tokens
+
+---
+
+## Related examples
+
+- `examples/tokens/01-sep41-token` — minimal SEP-41 token with basic approve
+  and transfer
+- `examples/advanced/05-batch-transfer` — standalone batch transfer contract
+  with detailed gas optimisation commentary
+- `examples/tokens/allowance-pattern` — allowance lifecycle with expiration

--- a/examples/tokens/02-sep41-extensions/src/lib.rs
+++ b/examples/tokens/02-sep41-extensions/src/lib.rs
@@ -1,0 +1,459 @@
+//! # SEP-41 Extensions
+//!
+//! Optional extensions to a standard SEP-41 token contract.
+//!
+//! Key patterns shown:
+//! - **Permit** (EIP-2612 equivalent): off-chain signature-based approvals so
+//!   users can authorise a spender without a separate on-chain `approve` call.
+//! - **Batch transfer**: send different amounts to multiple recipients in one
+//!   call, debiting the sender's balance only once.
+//! - **Batch approve**: set multiple allowances atomically.
+//!
+//! ## Design notes
+//!
+//! `permit` in Soroban does not use secp256k1 signatures as Ethereum does;
+//! instead it relies on Soroban's built-in auth framework.  The caller
+//! provides a signed authorization envelope via `require_auth_for_args` which
+//! the host verifies against the owner's key material.  From the caller's
+//! perspective the effect is identical to EIP-2612: a spender can be approved
+//! without the owner ever submitting a separate approve transaction.
+//!
+//! ## Use cases
+//!
+//! - **Gasless approve flows**: a relayer calls `permit` on behalf of the
+//!   owner, bundled with the downstream `transfer_from` in one transaction.
+//! - **Batch payroll**: fund many addresses in a single call.
+//! - **Bulk allowance management**: set allowances for many spenders at once.
+
+#![no_std]
+
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env, IntoVal,
+    Symbol, Vec,
+};
+
+// ---------------------------------------------------------------------------
+// Storage keys
+// ---------------------------------------------------------------------------
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    /// Token balance of an address.
+    Balance(Address),
+    /// Allowance: how much `spender` may draw from `owner`.
+    Allowance(Address, Address),
+    /// Expiration ledger for an allowance.
+    AllowanceExpiry(Address, Address),
+    /// Whether the contract has been initialised.
+    Initialized,
+}
+
+// ---------------------------------------------------------------------------
+// Transfer / Approval descriptors
+// ---------------------------------------------------------------------------
+
+/// A `(recipient, amount)` pair used in `batch_transfer`.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Transfer {
+    pub to: Address,
+    pub amount: i128,
+}
+
+/// A `(spender, amount, expiration_ledger)` triple used in `batch_approve`.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Approval {
+    pub spender: Address,
+    pub amount: i128,
+    pub expiration_ledger: u32,
+}
+
+// ---------------------------------------------------------------------------
+// Events
+// ---------------------------------------------------------------------------
+
+const NS: Symbol = symbol_short!("sep41ext");
+const EV_XFER: Symbol = symbol_short!("transfer");
+const EV_APPR: Symbol = symbol_short!("approve");
+const EV_PERMIT: Symbol = symbol_short!("permit");
+const EV_MINT: Symbol = symbol_short!("mint");
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum ExtError {
+    /// The contract was already initialised.
+    AlreadyInitialized = 1,
+    /// The contract has not been initialised.
+    NotInitialized = 2,
+    /// An amount is zero or negative where a positive value is required.
+    InvalidAmount = 3,
+    /// The sender does not hold enough tokens.
+    InsufficientBalance = 4,
+    /// A drawn allowance exceeds what was granted.
+    InsufficientAllowance = 5,
+    /// An overflow was detected during arithmetic.
+    ArithmeticOverflow = 6,
+    /// The batch list is empty.
+    EmptyBatch = 7,
+    /// The permit's expiration ledger is already in the past.
+    ExpiredPermit = 8,
+}
+
+// ---------------------------------------------------------------------------
+// Contract
+// ---------------------------------------------------------------------------
+
+#[contract]
+pub struct Sep41Extensions;
+
+#[contractimpl]
+impl Sep41Extensions {
+    // -----------------------------------------------------------------------
+    // Initialisation
+    // -----------------------------------------------------------------------
+
+    /// Initialise and mint `initial_supply` to `admin`.  Can only be called
+    /// once.
+    pub fn initialize(env: Env, admin: Address, initial_supply: i128) -> Result<(), ExtError> {
+        if env.storage().instance().has(&DataKey::Initialized) {
+            return Err(ExtError::AlreadyInitialized);
+        }
+        if initial_supply <= 0 {
+            return Err(ExtError::InvalidAmount);
+        }
+
+        env.storage().instance().set(&DataKey::Initialized, &true);
+        write_balance(&env, &admin, initial_supply);
+
+        env.events()
+            .publish((NS, EV_MINT, admin.clone()), initial_supply);
+
+        Ok(())
+    }
+
+    // -----------------------------------------------------------------------
+    // Extension 1: permit (EIP-2612 equivalent)
+    // -----------------------------------------------------------------------
+
+    /// Approve `spender` to transfer up to `amount` from `owner`, valid
+    /// through `expiration_ledger`, using an off-chain signature.
+    ///
+    /// The owner does not need to submit a separate on-chain `approve`.
+    /// Instead the owner signs an authorisation envelope off-chain; the
+    /// spender (or a relayer) submits this call with that signature attached.
+    ///
+    /// Soroban's `require_auth_for_args` ties the authorisation to the exact
+    /// arguments, preventing replay and argument substitution.
+    pub fn permit(
+        env: Env,
+        owner: Address,
+        spender: Address,
+        amount: i128,
+        expiration_ledger: u32,
+    ) -> Result<(), ExtError> {
+        ensure_initialized(&env)?;
+
+        if amount < 0 {
+            return Err(ExtError::InvalidAmount);
+        }
+        if amount > 0 && expiration_ledger < env.ledger().sequence() {
+            return Err(ExtError::ExpiredPermit);
+        }
+
+        // Bind the auth to these exact arguments so it cannot be replayed
+        // with different parameters.
+        owner.require_auth_for_args((spender.clone(), amount, expiration_ledger).into_val(&env));
+
+        write_allowance(&env, &owner, &spender, amount);
+        write_expiry(&env, &owner, &spender, expiration_ledger);
+
+        env.events().publish(
+            (NS, EV_PERMIT, owner.clone(), spender.clone()),
+            (amount, expiration_ledger),
+        );
+
+        Ok(())
+    }
+
+    // -----------------------------------------------------------------------
+    // Extension 2: batch transfer
+    // -----------------------------------------------------------------------
+
+    /// Transfer tokens from `from` to multiple recipients atomically.
+    ///
+    /// The sender's balance is read once and written once regardless of the
+    /// number of recipients, making this substantially cheaper than looping
+    /// over individual `transfer` calls.
+    pub fn batch_transfer(
+        env: Env,
+        from: Address,
+        transfers: Vec<Transfer>,
+    ) -> Result<u32, ExtError> {
+        from.require_auth();
+        ensure_initialized(&env)?;
+
+        let count = transfers.len();
+        if count == 0 {
+            return Err(ExtError::EmptyBatch);
+        }
+
+        // Validation pass: sum total, reject non-positive amounts.
+        let mut total: i128 = 0;
+        for item in transfers.iter() {
+            if item.amount <= 0 {
+                return Err(ExtError::InvalidAmount);
+            }
+            total = total
+                .checked_add(item.amount)
+                .ok_or(ExtError::ArithmeticOverflow)?;
+        }
+
+        // Single balance read.
+        let sender_bal = read_balance(&env, &from);
+        if sender_bal < total {
+            return Err(ExtError::InsufficientBalance);
+        }
+
+        // Mutations: debit sender once, credit each recipient once.
+        write_balance(&env, &from, sender_bal - total);
+
+        for item in transfers.iter() {
+            let old = read_balance(&env, &item.to);
+            let new_bal = old
+                .checked_add(item.amount)
+                .ok_or(ExtError::ArithmeticOverflow)?;
+            write_balance(&env, &item.to, new_bal);
+
+            env.events()
+                .publish((NS, EV_XFER, from.clone(), item.to.clone()), item.amount);
+        }
+
+        Ok(count)
+    }
+
+    // -----------------------------------------------------------------------
+    // Extension 3: batch approve
+    // -----------------------------------------------------------------------
+
+    /// Set multiple allowances for `owner` in a single call.
+    ///
+    /// Each entry in `approvals` specifies a `spender`, the `amount` to
+    /// authorise, and the `expiration_ledger` after which the allowance
+    /// becomes invalid.  Passing `amount = 0` revokes that spender's
+    /// allowance.
+    pub fn batch_approve(
+        env: Env,
+        owner: Address,
+        approvals: Vec<Approval>,
+    ) -> Result<u32, ExtError> {
+        owner.require_auth();
+        ensure_initialized(&env)?;
+
+        let count = approvals.len();
+        if count == 0 {
+            return Err(ExtError::EmptyBatch);
+        }
+
+        for item in approvals.iter() {
+            if item.amount < 0 {
+                return Err(ExtError::InvalidAmount);
+            }
+
+            write_allowance(&env, &owner, &item.spender, item.amount);
+            write_expiry(&env, &owner, &item.spender, item.expiration_ledger);
+
+            env.events().publish(
+                (NS, EV_APPR, owner.clone(), item.spender.clone()),
+                (item.amount, item.expiration_ledger),
+            );
+        }
+
+        Ok(count)
+    }
+
+    // -----------------------------------------------------------------------
+    // Standard transfer / transfer_from / approve
+    // -----------------------------------------------------------------------
+
+    /// Standard token transfer.
+    pub fn transfer(env: Env, from: Address, to: Address, amount: i128) -> Result<(), ExtError> {
+        from.require_auth();
+        ensure_initialized(&env)?;
+        require_positive(amount)?;
+
+        let from_bal = read_balance(&env, &from);
+        if from_bal < amount {
+            return Err(ExtError::InsufficientBalance);
+        }
+        let to_bal = read_balance(&env, &to);
+        let new_to = to_bal
+            .checked_add(amount)
+            .ok_or(ExtError::ArithmeticOverflow)?;
+
+        write_balance(&env, &from, from_bal - amount);
+        write_balance(&env, &to, new_to);
+
+        env.events()
+            .publish((NS, EV_XFER, from.clone(), to.clone()), amount);
+
+        Ok(())
+    }
+
+    /// Approve a spender via the standard on-chain path.
+    pub fn approve(
+        env: Env,
+        owner: Address,
+        spender: Address,
+        amount: i128,
+        expiration_ledger: u32,
+    ) -> Result<(), ExtError> {
+        owner.require_auth();
+        ensure_initialized(&env)?;
+
+        if amount < 0 {
+            return Err(ExtError::InvalidAmount);
+        }
+
+        write_allowance(&env, &owner, &spender, amount);
+        write_expiry(&env, &owner, &spender, expiration_ledger);
+
+        env.events().publish(
+            (NS, EV_APPR, owner.clone(), spender.clone()),
+            (amount, expiration_ledger),
+        );
+
+        Ok(())
+    }
+
+    /// Transfer using an existing allowance.
+    pub fn transfer_from(
+        env: Env,
+        spender: Address,
+        owner: Address,
+        to: Address,
+        amount: i128,
+    ) -> Result<(), ExtError> {
+        spender.require_auth();
+        ensure_initialized(&env)?;
+        require_positive(amount)?;
+
+        let expiry = read_expiry(&env, &owner, &spender);
+        let allowance = if expiry > 0 && expiry < env.ledger().sequence() {
+            0
+        } else {
+            read_allowance(&env, &owner, &spender)
+        };
+
+        if allowance < amount {
+            return Err(ExtError::InsufficientAllowance);
+        }
+
+        let owner_bal = read_balance(&env, &owner);
+        if owner_bal < amount {
+            return Err(ExtError::InsufficientBalance);
+        }
+        let to_bal = read_balance(&env, &to);
+        let new_to = to_bal
+            .checked_add(amount)
+            .ok_or(ExtError::ArithmeticOverflow)?;
+
+        write_allowance(&env, &owner, &spender, allowance - amount);
+        write_balance(&env, &owner, owner_bal - amount);
+        write_balance(&env, &to, new_to);
+
+        env.events()
+            .publish((NS, EV_XFER, owner.clone(), to.clone()), amount);
+
+        Ok(())
+    }
+
+    // -----------------------------------------------------------------------
+    // Queries
+    // -----------------------------------------------------------------------
+
+    /// Return the token balance for `user`.
+    pub fn balance(env: Env, user: Address) -> i128 {
+        read_balance(&env, &user)
+    }
+
+    /// Return the current allowance `spender` holds from `owner`.
+    ///
+    /// Returns `0` if the allowance has expired.
+    pub fn allowance(env: Env, owner: Address, spender: Address) -> i128 {
+        let expiry = read_expiry(&env, &owner, &spender);
+        if expiry > 0 && expiry < env.ledger().sequence() {
+            return 0;
+        }
+        read_allowance(&env, &owner, &spender)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------------
+
+fn ensure_initialized(env: &Env) -> Result<(), ExtError> {
+    if env.storage().instance().has(&DataKey::Initialized) {
+        Ok(())
+    } else {
+        Err(ExtError::NotInitialized)
+    }
+}
+
+fn require_positive(amount: i128) -> Result<(), ExtError> {
+    if amount <= 0 {
+        Err(ExtError::InvalidAmount)
+    } else {
+        Ok(())
+    }
+}
+
+fn read_balance(env: &Env, user: &Address) -> i128 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Balance(user.clone()))
+        .unwrap_or(0)
+}
+
+fn write_balance(env: &Env, user: &Address, amount: i128) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Balance(user.clone()), &amount);
+}
+
+fn read_allowance(env: &Env, owner: &Address, spender: &Address) -> i128 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Allowance(owner.clone(), spender.clone()))
+        .unwrap_or(0)
+}
+
+fn write_allowance(env: &Env, owner: &Address, spender: &Address, amount: i128) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Allowance(owner.clone(), spender.clone()), &amount);
+}
+
+fn read_expiry(env: &Env, owner: &Address, spender: &Address) -> u32 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::AllowanceExpiry(owner.clone(), spender.clone()))
+        .unwrap_or(0)
+}
+
+fn write_expiry(env: &Env, owner: &Address, spender: &Address, expiry: u32) {
+    env.storage().persistent().set(
+        &DataKey::AllowanceExpiry(owner.clone(), spender.clone()),
+        &expiry,
+    );
+}
+
+#[cfg(test)]
+mod test;

--- a/examples/tokens/02-sep41-extensions/src/test.rs
+++ b/examples/tokens/02-sep41-extensions/src/test.rs
@@ -1,0 +1,368 @@
+extern crate std;
+
+use super::*;
+use soroban_sdk::{testutils::Address as _, Address, Env, Vec};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn setup(supply: i128) -> (Env, Sep41ExtensionsClient<'static>, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, Sep41Extensions);
+    let client = Sep41ExtensionsClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin, &supply);
+    (env, client, admin)
+}
+
+// ---------------------------------------------------------------------------
+// Initialisation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_initialize_sets_balance() {
+    let (env, client, admin) = setup(1_000);
+    assert_eq!(client.balance(&admin), 1_000);
+    let _ = env;
+}
+
+#[test]
+fn test_initialize_double_call_fails() {
+    let (env, client, admin) = setup(1_000);
+    let result = client.try_initialize(&admin, &500);
+    assert_eq!(result, Err(Ok(ExtError::AlreadyInitialized)));
+    let _ = env;
+}
+
+#[test]
+fn test_initialize_zero_supply_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, Sep41Extensions);
+    let client = Sep41ExtensionsClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    assert_eq!(
+        client.try_initialize(&admin, &0),
+        Err(Ok(ExtError::InvalidAmount))
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Permit tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_permit_sets_allowance() {
+    let (env, client, owner) = setup(1_000);
+    let spender = Address::generate(&env);
+
+    client.permit(&owner, &spender, &500, &100_000);
+
+    assert_eq!(client.allowance(&owner, &spender), 500);
+}
+
+#[test]
+fn test_permit_expired_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, Sep41Extensions);
+    let client = Sep41ExtensionsClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin, &1_000);
+
+    let spender = Address::generate(&env);
+    // ledger sequence is 0 by default; expiration_ledger = 0 with amount > 0 is expired
+    // We set a past ledger by advancing the ledger past the expiry.
+    // Default sequence is 0, and 0 < 0 is false, so let's advance the ledger.
+    // Actually: expiry 0 with amount > 0 means expiry < current sequence only if current > 0.
+    // Let's use expiry = 1 with ledger advanced to 2.
+    use soroban_sdk::testutils::Ledger as _;
+    env.ledger().set_sequence_number(2);
+
+    let result = client.try_permit(&admin, &spender, &100, &1);
+    assert_eq!(result, Err(Ok(ExtError::ExpiredPermit)));
+}
+
+#[test]
+fn test_permit_zero_amount_revokes() {
+    let (env, client, owner) = setup(1_000);
+    let spender = Address::generate(&env);
+
+    client.permit(&owner, &spender, &500, &100_000);
+    assert_eq!(client.allowance(&owner, &spender), 500);
+
+    // Revoke by setting amount to 0
+    client.permit(&owner, &spender, &0, &0);
+    assert_eq!(client.allowance(&owner, &spender), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Batch transfer tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_batch_transfer_single_recipient() {
+    let (env, client, admin) = setup(1_000);
+    let r = Address::generate(&env);
+
+    let transfers = Vec::from_array(
+        &env,
+        [Transfer {
+            to: r.clone(),
+            amount: 300,
+        }],
+    );
+    let count = client.batch_transfer(&admin, &transfers);
+
+    assert_eq!(count, 1);
+    assert_eq!(client.balance(&admin), 700);
+    assert_eq!(client.balance(&r), 300);
+}
+
+#[test]
+fn test_batch_transfer_multiple_recipients() {
+    let (env, client, admin) = setup(1_000);
+    let r1 = Address::generate(&env);
+    let r2 = Address::generate(&env);
+    let r3 = Address::generate(&env);
+
+    let transfers = Vec::from_array(
+        &env,
+        [
+            Transfer {
+                to: r1.clone(),
+                amount: 100,
+            },
+            Transfer {
+                to: r2.clone(),
+                amount: 200,
+            },
+            Transfer {
+                to: r3.clone(),
+                amount: 300,
+            },
+        ],
+    );
+    let count = client.batch_transfer(&admin, &transfers);
+
+    assert_eq!(count, 3);
+    assert_eq!(client.balance(&admin), 400);
+    assert_eq!(client.balance(&r1), 100);
+    assert_eq!(client.balance(&r2), 200);
+    assert_eq!(client.balance(&r3), 300);
+}
+
+#[test]
+fn test_batch_transfer_empty_fails() {
+    let (env, client, admin) = setup(1_000);
+    let empty: Vec<Transfer> = Vec::new(&env);
+    assert_eq!(
+        client.try_batch_transfer(&admin, &empty),
+        Err(Ok(ExtError::EmptyBatch))
+    );
+}
+
+#[test]
+fn test_batch_transfer_insufficient_balance_fails() {
+    let (env, client, admin) = setup(100);
+    let r1 = Address::generate(&env);
+    let r2 = Address::generate(&env);
+
+    let transfers = Vec::from_array(
+        &env,
+        [
+            Transfer {
+                to: r1.clone(),
+                amount: 70,
+            },
+            Transfer {
+                to: r2.clone(),
+                amount: 50,
+            }, // 70+50 = 120 > 100
+        ],
+    );
+    assert_eq!(
+        client.try_batch_transfer(&admin, &transfers),
+        Err(Ok(ExtError::InsufficientBalance))
+    );
+    // No state mutation
+    assert_eq!(client.balance(&admin), 100);
+    assert_eq!(client.balance(&r1), 0);
+}
+
+#[test]
+fn test_batch_transfer_zero_amount_fails() {
+    let (env, client, admin) = setup(1_000);
+    let r = Address::generate(&env);
+
+    let transfers = Vec::from_array(
+        &env,
+        [
+            Transfer {
+                to: r.clone(),
+                amount: 100,
+            },
+            Transfer {
+                to: r.clone(),
+                amount: 0,
+            },
+        ],
+    );
+    assert_eq!(
+        client.try_batch_transfer(&admin, &transfers),
+        Err(Ok(ExtError::InvalidAmount))
+    );
+    assert_eq!(client.balance(&admin), 1_000);
+}
+
+// ---------------------------------------------------------------------------
+// Batch approve tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_batch_approve_sets_allowances() {
+    let (env, client, owner) = setup(1_000);
+    let s1 = Address::generate(&env);
+    let s2 = Address::generate(&env);
+
+    let approvals = Vec::from_array(
+        &env,
+        [
+            Approval {
+                spender: s1.clone(),
+                amount: 200,
+                expiration_ledger: 100_000,
+            },
+            Approval {
+                spender: s2.clone(),
+                amount: 500,
+                expiration_ledger: 100_000,
+            },
+        ],
+    );
+    let count = client.batch_approve(&owner, &approvals);
+
+    assert_eq!(count, 2);
+    assert_eq!(client.allowance(&owner, &s1), 200);
+    assert_eq!(client.allowance(&owner, &s2), 500);
+}
+
+#[test]
+fn test_batch_approve_empty_fails() {
+    let (env, client, owner) = setup(1_000);
+    let empty: Vec<Approval> = Vec::new(&env);
+    assert_eq!(
+        client.try_batch_approve(&owner, &empty),
+        Err(Ok(ExtError::EmptyBatch))
+    );
+}
+
+#[test]
+fn test_batch_approve_negative_amount_fails() {
+    let (env, client, owner) = setup(1_000);
+    let s = Address::generate(&env);
+
+    let approvals = Vec::from_array(
+        &env,
+        [Approval {
+            spender: s.clone(),
+            amount: -1,
+            expiration_ledger: 100_000,
+        }],
+    );
+    assert_eq!(
+        client.try_batch_approve(&owner, &approvals),
+        Err(Ok(ExtError::InvalidAmount))
+    );
+}
+
+#[test]
+fn test_batch_approve_revoke_with_zero() {
+    let (env, client, owner) = setup(1_000);
+    let s = Address::generate(&env);
+
+    let set = Vec::from_array(
+        &env,
+        [Approval {
+            spender: s.clone(),
+            amount: 300,
+            expiration_ledger: 100_000,
+        }],
+    );
+    client.batch_approve(&owner, &set);
+    assert_eq!(client.allowance(&owner, &s), 300);
+
+    let revoke = Vec::from_array(
+        &env,
+        [Approval {
+            spender: s.clone(),
+            amount: 0,
+            expiration_ledger: 0,
+        }],
+    );
+    client.batch_approve(&owner, &revoke);
+    assert_eq!(client.allowance(&owner, &s), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Standard transfer tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_transfer_basic() {
+    let (env, client, admin) = setup(1_000);
+    let bob = Address::generate(&env);
+
+    client.transfer(&admin, &bob, &400);
+
+    assert_eq!(client.balance(&admin), 600);
+    assert_eq!(client.balance(&bob), 400);
+}
+
+#[test]
+fn test_transfer_insufficient_balance_fails() {
+    let (env, client, admin) = setup(100);
+    let bob = Address::generate(&env);
+
+    assert_eq!(
+        client.try_transfer(&admin, &bob, &200),
+        Err(Ok(ExtError::InsufficientBalance))
+    );
+}
+
+// ---------------------------------------------------------------------------
+// transfer_from / allowance tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_transfer_from_with_permit_allowance() {
+    let (env, client, owner) = setup(1_000);
+    let spender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+
+    // Grant allowance via permit
+    client.permit(&owner, &spender, &300, &100_000);
+
+    // Spender draws from the allowance
+    client.transfer_from(&spender, &owner, &recipient, &200);
+
+    assert_eq!(client.balance(&owner), 800);
+    assert_eq!(client.balance(&recipient), 200);
+    assert_eq!(client.allowance(&owner, &spender), 100);
+}
+
+#[test]
+fn test_transfer_from_exceeds_allowance_fails() {
+    let (env, client, owner) = setup(1_000);
+    let spender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+
+    client.permit(&owner, &spender, &100, &100_000);
+
+    assert_eq!(
+        client.try_transfer_from(&spender, &owner, &recipient, &200),
+        Err(Ok(ExtError::InsufficientAllowance))
+    );
+}

--- a/examples/tokens/README.md
+++ b/examples/tokens/README.md
@@ -14,6 +14,7 @@ This category contains examples related to fungible tokens, including implementa
 ## Examples
 
 - `01-sep41-token`: A minimal SEP-41-compliant fungible token contract.
+- `02-sep41-extensions`: Optional SEP-41 extensions — permit (EIP-2612 equivalent), batch transfer, and batch approve.
 - `02-vesting-contract`: A contract that releases tokens to a beneficiary over time.
 - `04-airdrop-contract`: A contract to efficiently distribute tokens to a list of addresses.
 - `05-wrapped-asset`: A contract that creates a Soroban-native representation of a classic Stellar asset.


### PR DESCRIPTION
## Summary

Closes #645 — adds `examples/tokens/02-sep41-extensions/` implementing optional SEP-41 token extensions.

**Permit (EIP-2612 equivalent)**
- Owner signs authorisation off-chain; spender (or relayer) submits `permit()` with the envelope attached
- `require_auth_for_args` binds auth to `(spender, amount, expiration_ledger)`, preventing replay with different arguments
- Expired permits are rejected at the contract level

**Batch transfer**
- Atomic multi-recipient transfer with a single sender balance read/write
- Full validation pass (positive amounts, sufficient balance) before any storage mutation

**Batch approve**
- Set multiple `(spender, amount, expiration_ledger)` allowances in one call
- Passing `amount = 0` revokes the allowance for that spender

Also updates `examples/tokens/README.md` to list the new example.

## Test plan

- [x] `cargo test -p sep41-extensions` — 19/19 pass
- [x] `cargo fmt -p sep41-extensions -- --check` — clean
- [x] CI clippy/test/build will run on PR open

🤖 Generated with [Claude Code](https://claude.com/claude-code)