### PR TITLE
Add diamond pattern base example (EIP-2535 Soroban adaptation)

### DIFF
--- a/examples/advanced/06-diamond-pattern/Cargo.toml
+++ b/examples/advanced/06-diamond-pattern/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "diamond-pattern"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/examples/advanced/06-diamond-pattern/README.md
+++ b/examples/advanced/06-diamond-pattern/README.md
@@ -1,0 +1,139 @@
+# Diamond Pattern Base (EIP-2535 Soroban Adaptation)
+
+A fully dynamic, introspectable diamond routing system for Soroban — the on-chain equivalent of EIP-2535.
+
+## What You'll Learn
+
+- How the **diamond storage pattern** prevents key collisions across facets using a namespaced `DataKey` enum
+- How to implement a **facet registry** with add, replace, and remove operations (diamond cut)
+- How to map **function selectors** (`Symbol` identifiers) to facet contract addresses at runtime
+- How to implement a **fallback dispatch mechanism** using loupe introspection
+- How to write **diamond-loupe** functions that expose the complete routing table on-chain
+
+## Contract Overview
+
+### DiamondBase
+
+The core diamond contract. It owns the `selector → facet-address` routing table and exposes:
+
+| Function | Description |
+|----------|-------------|
+| `initialize(admin)` | Bootstrap the diamond (once only) |
+| `diamond_cut(admin, cuts)` | Batch add / replace / remove facet selectors |
+| `facets()` | Loupe: all facets and their selectors |
+| `facet_addresses()` | Loupe: all registered facet addresses |
+| `facet_function_selectors(facet)` | Loupe: selectors served by a specific facet |
+| `facet_address(selector)` | Loupe + fallback: which facet handles a selector |
+| `selector_count()` | Total number of registered selectors |
+
+### TokenFacet
+
+Demonstrates the diamond storage pattern in a token context. All state lives under the `Tf*` `DataKey` variants — completely isolated from any other facet's storage.
+
+### CounterFacet
+
+A second independent facet with its own `Cf*` storage namespace, proving that multiple facets coexist without key collisions.
+
+## Key Concepts
+
+### Diamond Storage Pattern
+
+In EIP-2535, each facet stores its data at a deterministic keccak256 slot to avoid layout collisions. Soroban achieves the same guarantee via enum variant discrimination: `TfBalance(owner)` and `CfCount(name)` use different discriminants and can never occupy the same storage entry, even when the parameter values are identical.
+
+```rust
+#[contracttype]
+pub enum DataKey {
+    // Diamond registry
+    SelectorFacet(Symbol),      // selector → facet address
+    FacetSelectorList(Address), // facet → its selectors
+
+    // TokenFacet namespace
+    TfBalance(Address),         // isolated from CounterFacet
+    TfTotalSupply,
+
+    // CounterFacet namespace
+    CfCount(Symbol),            // isolated from TokenFacet
+}
+```
+
+### Facet Registry (Diamond Cut)
+
+Facets are registered dynamically at runtime:
+
+```rust
+let mut cuts = Vec::new(&env);
+cuts.push_back(FacetCut {
+    facet_address: token_contract_id,
+    action: FacetCutAction::Add,
+    selectors: vec![&env, symbol_short!("tf_mint"), symbol_short!("tf_trsf")],
+});
+diamond.diamond_cut(&admin, &cuts);
+```
+
+Three actions mirror EIP-2535:
+- **Add** — register new selectors pointing to a new facet
+- **Replace** — re-point existing selectors to a different facet
+- **Remove** — deregister selectors entirely (prunes the facet from the list when empty)
+
+### Function Selector Mapping
+
+`Symbol` values serve as function selectors. The registry maps each selector to the facet address that implements it:
+
+```rust
+// Register
+diamond.diamond_cut(&admin, &[FacetCut {
+    facet_address: token_id,
+    action: FacetCutAction::Add,
+    selectors: vec![&env, symbol_short!("tf_mint")],
+}]);
+
+// Lookup
+let facet = diamond.facet_address(&symbol_short!("tf_mint")); // Some(token_id)
+```
+
+### Fallback Dispatch Mechanism
+
+Callers resolve the correct facet contract via `facet_address`, then dispatch to it directly — the Soroban equivalent of EIP-2535's fallback function routing:
+
+```rust
+let facet_addr = diamond
+    .facet_address(&symbol_short!("tf_mint"))
+    .expect("selector not registered");
+
+// Dispatch to the resolved facet
+let token_client = TokenFacetClient::new(&env, &facet_addr);
+token_client.tf_mint(&minter, &recipient, &1_000i128);
+```
+
+## Security Considerations
+
+- **Admin-only cuts**: Only the address set during `initialize` may call `diamond_cut`. Adding multi-sig or timelock control on top is strongly recommended for production use.
+- **No duplicate selectors**: `Add` panics on duplicate registrations, preventing accidental shadowing.
+- **Replace enforces existence**: `Replace` panics if the selector is not already registered, ensuring routing tables stay consistent.
+- **Namespace isolation**: The `DataKey` enum guarantees that facet A's storage is never readable or writable by facet B, eliminating cross-facet storage corruption.
+- **Facet pruning**: `Remove` automatically drops facets with no remaining selectors from the global list, keeping the loupe data accurate.
+
+## Testing
+
+```bash
+cargo test -p diamond-pattern
+```
+
+The test suite covers 22 scenarios:
+- Diamond initialisation and double-init guard
+- Diamond cut: add, replace, remove, duplicate-add guard
+- Diamond loupe: facets, addresses, per-facet selectors, unknown selectors
+- Fallback dispatch via loupe resolution
+- TokenFacet: mint, transfer, insufficient-balance guard, approve + transfer-from, allowance-exceeded guard
+- CounterFacet: increment, reset, independent named counters
+- Cross-facet storage isolation
+
+## Building
+
+```bash
+# Native (for tests)
+cargo build -p diamond-pattern
+
+# WASM (for on-chain deployment)
+cargo build --target wasm32-unknown-unknown --release -p diamond-pattern
+```

--- a/examples/advanced/06-diamond-pattern/src/lib.rs
+++ b/examples/advanced/06-diamond-pattern/src/lib.rs
@@ -1,0 +1,655 @@
+//! # Diamond Pattern Base (EIP-2535 Soroban Adaptation)
+//!
+//! Soroban's adaptation of the EIP-2535 Diamond Standard. Because Soroban
+//! lacks `delegatecall`, the pattern is realised as:
+//!
+//! 1. **Diamond storage** — a single `DataKey` enum whose variant tags act as
+//!    per-facet namespace prefixes, guaranteeing storage isolation across all
+//!    facets without any key collisions.
+//!
+//! 2. **Facet registry** — the [`DiamondBase`] contract maintains a dynamic
+//!    `selector → facet-address` mapping that can be updated at runtime via
+//!    diamond-cut operations.
+//!
+//! 3. **Function selector mapping** — each logical function is identified by a
+//!    [`Symbol`] selector stored in the registry.
+//!
+//! 4. **Fallback mechanism** — callers resolve the correct facet address via
+//!    [`DiamondBase::facet_address`] and dispatch to it directly, mirroring
+//!    how EIP-2535 fallback routing works at the router level.
+//!
+//! ## Architecture
+//!
+//! ```text
+//! ┌──────────────────────────────────────────────────────────┐
+//! │                       DiamondBase                        │
+//! │  diamond_cut  │  facets  │  facet_address (fallback)     │
+//! └───────────────────────────────┬──────────────────────────┘
+//!                                 │ selector → facet lookup
+//!               ┌─────────────────┼─────────────────────┐
+//!               ▼                 ▼                       ▼
+//!         TokenFacet          CounterFacet           (any facet)
+//!    TfBalance / TfSupply   CfCount(name)         isolated namespace
+//! ```
+
+#![no_std]
+#![allow(deprecated)]
+
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, Symbol, Vec};
+
+// ---------------------------------------------------------------------------
+// Diamond cut types
+// ---------------------------------------------------------------------------
+
+/// The operation to apply to a set of function selectors during a diamond cut.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum FacetCutAction {
+    /// Register new selectors mapped to a new facet contract.
+    Add,
+    /// Re-map existing selectors to a different facet contract.
+    Replace,
+    /// Remove selectors, erasing their facet mapping entirely.
+    Remove,
+}
+
+/// Describes one facet change within a [`DiamondBase::diamond_cut`] batch.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct FacetCut {
+    /// Target facet contract address. Unused (but must be present) for `Remove`.
+    pub facet_address: Address,
+    /// The operation: Add, Replace, or Remove.
+    pub action: FacetCutAction,
+    /// The [`Symbol`] function selectors to add, replace, or remove.
+    pub selectors: Vec<Symbol>,
+}
+
+/// Facet information returned by the diamond-loupe introspection functions.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct FacetInfo {
+    /// On-chain contract address of this facet.
+    pub facet_address: Address,
+    /// All function selectors currently routed to this facet.
+    pub selectors: Vec<Symbol>,
+}
+
+// ---------------------------------------------------------------------------
+// Diamond storage pattern — namespaced DataKey enum
+// ---------------------------------------------------------------------------
+
+/// Unified storage key enum for the diamond and every registered facet.
+///
+/// The variant tag acts as an implicit namespace: `TfBalance(owner)` can
+/// never collide with `CfCount(name)` even though both hold per-address or
+/// per-name values. This is the Soroban realisation of the EIP-2535 diamond
+/// storage pattern — isolation without hash slots.
+#[contracttype]
+pub enum DataKey {
+    // ── Diamond core storage ──────────────────────────────────────────────
+    /// The admin address authorised to invoke `diamond_cut`.
+    Admin,
+    /// Ordered list of every registered function selector.
+    SelectorList,
+    /// Ordered list of every unique registered facet address.
+    FacetList,
+    /// `SelectorFacet(selector)` → Address: which facet handles this selector.
+    SelectorFacet(Symbol),
+    /// `FacetSelectorList(facet)` → Vec<Symbol>: selectors served by a facet.
+    FacetSelectorList(Address),
+
+    // ── TokenFacet storage namespace (tf_ prefix) ─────────────────────────
+    /// ERC-20-style balance per owner.
+    TfBalance(Address),
+    /// ERC-20-style spend allowance per (owner, spender) pair.
+    TfAllowance(Address, Address),
+    /// Aggregate token supply.
+    TfTotalSupply,
+
+    // ── CounterFacet storage namespace (cf_ prefix) ───────────────────────
+    /// Named counter value.
+    CfCount(Symbol),
+}
+
+// ---------------------------------------------------------------------------
+// Event namespaces
+// ---------------------------------------------------------------------------
+
+const NS_DIAMOND: Symbol = symbol_short!("diamond");
+const NS_TOKEN: Symbol = symbol_short!("token");
+const NS_COUNTER: Symbol = symbol_short!("counter");
+
+// ---------------------------------------------------------------------------
+// DiamondBase — registry, loupe, and cut
+// ---------------------------------------------------------------------------
+
+/// Core diamond contract that owns the selector → facet routing table.
+///
+/// Supports dynamic reconfiguration (diamond cut) and full introspection
+/// (diamond loupe). Concrete facet contracts demonstrate the diamond storage
+/// pattern by using isolated `DataKey` namespace prefixes.
+#[contract]
+pub struct DiamondBase;
+
+#[contractimpl]
+impl DiamondBase {
+    // ── Initialisation ────────────────────────────────────────────────────
+
+    /// Bootstrap the diamond. Must be called exactly once.
+    ///
+    /// Sets the admin address that is permitted to invoke [`Self::diamond_cut`].
+    pub fn initialize(env: Env, admin: Address) {
+        assert!(
+            !env.storage().instance().has(&DataKey::Admin),
+            "already initialized"
+        );
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage()
+            .instance()
+            .set(&DataKey::SelectorList, &Vec::<Symbol>::new(&env));
+        env.storage()
+            .instance()
+            .set(&DataKey::FacetList, &Vec::<Address>::new(&env));
+
+        env.events()
+            .publish((NS_DIAMOND, symbol_short!("init"), admin), ());
+    }
+
+    // ── Diamond cut ───────────────────────────────────────────────────────
+
+    /// Apply a batch of facet cuts to reconfigure the diamond routing table.
+    ///
+    /// Each [`FacetCut`] entry may add new selectors, replace existing ones,
+    /// or remove selectors entirely. Only the diamond admin may call this.
+    pub fn diamond_cut(env: Env, admin: Address, cuts: Vec<FacetCut>) {
+        admin.require_auth();
+        Self::assert_admin(&env, &admin);
+
+        for cut in cuts.iter() {
+            match cut.action {
+                FacetCutAction::Add => {
+                    Self::apply_add(&env, &cut.facet_address, &cut.selectors);
+                }
+                FacetCutAction::Replace => {
+                    Self::apply_replace(&env, &cut.facet_address, &cut.selectors);
+                }
+                FacetCutAction::Remove => {
+                    Self::apply_remove(&env, &cut.selectors);
+                }
+            }
+        }
+
+        env.events()
+            .publish((NS_DIAMOND, symbol_short!("cut"), admin), cuts.len());
+    }
+
+    // ── Diamond loupe (introspection) ─────────────────────────────────────
+
+    /// Return all registered facets together with their function selectors.
+    pub fn facets(env: Env) -> Vec<FacetInfo> {
+        let facet_list: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::FacetList)
+            .unwrap_or_else(|| Vec::new(&env));
+
+        let mut result = Vec::new(&env);
+        for addr in facet_list.iter() {
+            let selectors: Vec<Symbol> = env
+                .storage()
+                .instance()
+                .get(&DataKey::FacetSelectorList(addr.clone()))
+                .unwrap_or_else(|| Vec::new(&env));
+            result.push_back(FacetInfo {
+                facet_address: addr.clone(),
+                selectors,
+            });
+        }
+        result
+    }
+
+    /// Return all unique facet contract addresses registered with the diamond.
+    pub fn facet_addresses(env: Env) -> Vec<Address> {
+        env.storage()
+            .instance()
+            .get(&DataKey::FacetList)
+            .unwrap_or_else(|| Vec::new(&env))
+    }
+
+    /// Return the function selectors served by `facet`.
+    pub fn facet_function_selectors(env: Env, facet: Address) -> Vec<Symbol> {
+        env.storage()
+            .instance()
+            .get(&DataKey::FacetSelectorList(facet))
+            .unwrap_or_else(|| Vec::new(&env))
+    }
+
+    /// Return the facet address that handles `selector`, or `None` if unregistered.
+    ///
+    /// This is the **fallback dispatch entry point**: callers resolve the
+    /// correct facet contract address here, then invoke it directly — the
+    /// Soroban equivalent of EIP-2535 fallback routing.
+    pub fn facet_address(env: Env, selector: Symbol) -> Option<Address> {
+        env.storage()
+            .instance()
+            .get(&DataKey::SelectorFacet(selector))
+    }
+
+    /// Return the total count of registered function selectors.
+    pub fn selector_count(env: Env) -> u32 {
+        let list: Vec<Symbol> = env
+            .storage()
+            .instance()
+            .get(&DataKey::SelectorList)
+            .unwrap_or_else(|| Vec::new(&env));
+        list.len()
+    }
+
+    // ── Private helpers ───────────────────────────────────────────────────
+
+    fn assert_admin(env: &Env, caller: &Address) {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("not initialized");
+        assert_eq!(caller, &admin, "caller is not admin");
+    }
+
+    /// Register new selectors pointing to `facet`.
+    ///
+    /// Panics if any selector is already registered — use `Replace` for that.
+    fn apply_add(env: &Env, facet: &Address, selectors: &Vec<Symbol>) {
+        let mut sel_list: Vec<Symbol> = env
+            .storage()
+            .instance()
+            .get(&DataKey::SelectorList)
+            .unwrap_or_else(|| Vec::new(env));
+
+        let mut facet_sels: Vec<Symbol> = env
+            .storage()
+            .instance()
+            .get(&DataKey::FacetSelectorList(facet.clone()))
+            .unwrap_or_else(|| Vec::new(env));
+
+        let mut facet_list: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::FacetList)
+            .unwrap_or_else(|| Vec::new(env));
+
+        if !addr_in_list(&facet_list, facet) {
+            facet_list.push_back(facet.clone());
+            env.storage()
+                .instance()
+                .set(&DataKey::FacetList, &facet_list);
+        }
+
+        for sel in selectors.iter() {
+            assert!(
+                !env.storage()
+                    .instance()
+                    .has(&DataKey::SelectorFacet(sel.clone())),
+                "selector already registered; use Replace"
+            );
+            env.storage()
+                .instance()
+                .set(&DataKey::SelectorFacet(sel.clone()), facet);
+            sel_list.push_back(sel.clone());
+            facet_sels.push_back(sel.clone());
+        }
+
+        env.storage()
+            .instance()
+            .set(&DataKey::SelectorList, &sel_list);
+        env.storage()
+            .instance()
+            .set(&DataKey::FacetSelectorList(facet.clone()), &facet_sels);
+    }
+
+    /// Re-map existing selectors to `new_facet`.
+    ///
+    /// Panics if any selector is not already registered — use `Add` for that.
+    fn apply_replace(env: &Env, new_facet: &Address, selectors: &Vec<Symbol>) {
+        let mut facet_list: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::FacetList)
+            .unwrap_or_else(|| Vec::new(env));
+
+        let mut new_facet_sels: Vec<Symbol> = env
+            .storage()
+            .instance()
+            .get(&DataKey::FacetSelectorList(new_facet.clone()))
+            .unwrap_or_else(|| Vec::new(env));
+
+        for sel in selectors.iter() {
+            let old_facet: Address = env
+                .storage()
+                .instance()
+                .get(&DataKey::SelectorFacet(sel.clone()))
+                .expect("selector not registered; use Add");
+
+            // Remove selector from old facet's list.
+            let old_sels: Vec<Symbol> = env
+                .storage()
+                .instance()
+                .get(&DataKey::FacetSelectorList(old_facet.clone()))
+                .unwrap_or_else(|| Vec::new(env));
+
+            let mut filtered_old = Vec::new(env);
+            for s in old_sels.iter() {
+                if s != sel {
+                    filtered_old.push_back(s.clone());
+                }
+            }
+            env.storage()
+                .instance()
+                .set(&DataKey::FacetSelectorList(old_facet), &filtered_old);
+
+            // Point the selector at the new facet.
+            env.storage()
+                .instance()
+                .set(&DataKey::SelectorFacet(sel.clone()), new_facet);
+
+            if !sym_in_list(&new_facet_sels, &sel) {
+                new_facet_sels.push_back(sel.clone());
+            }
+        }
+
+        if !addr_in_list(&facet_list, new_facet) {
+            facet_list.push_back(new_facet.clone());
+            env.storage()
+                .instance()
+                .set(&DataKey::FacetList, &facet_list);
+        }
+
+        env.storage().instance().set(
+            &DataKey::FacetSelectorList(new_facet.clone()),
+            &new_facet_sels,
+        );
+    }
+
+    /// Remove selectors from the routing table.
+    ///
+    /// Panics if any selector is not currently registered. Facets with no
+    /// remaining selectors are pruned from the global facet list.
+    fn apply_remove(env: &Env, selectors: &Vec<Symbol>) {
+        let mut sel_list: Vec<Symbol> = env
+            .storage()
+            .instance()
+            .get(&DataKey::SelectorList)
+            .unwrap_or_else(|| Vec::new(env));
+
+        let mut facet_list: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::FacetList)
+            .unwrap_or_else(|| Vec::new(env));
+
+        for sel in selectors.iter() {
+            let old_facet: Address = env
+                .storage()
+                .instance()
+                .get(&DataKey::SelectorFacet(sel.clone()))
+                .expect("selector not registered");
+
+            // Remove from this facet's per-facet selector list.
+            let facet_sels: Vec<Symbol> = env
+                .storage()
+                .instance()
+                .get(&DataKey::FacetSelectorList(old_facet.clone()))
+                .unwrap_or_else(|| Vec::new(env));
+
+            let mut updated_facet_sels = Vec::new(env);
+            for s in facet_sels.iter() {
+                if s != sel {
+                    updated_facet_sels.push_back(s.clone());
+                }
+            }
+            env.storage().instance().set(
+                &DataKey::FacetSelectorList(old_facet.clone()),
+                &updated_facet_sels,
+            );
+
+            // Prune the facet from the global list when it has no selectors left.
+            if updated_facet_sels.is_empty() {
+                let mut pruned = Vec::new(env);
+                for a in facet_list.iter() {
+                    if a != old_facet {
+                        pruned.push_back(a.clone());
+                    }
+                }
+                facet_list = pruned;
+            }
+
+            // Remove from the global selector list.
+            let mut updated_global = Vec::new(env);
+            for s in sel_list.iter() {
+                if s != sel {
+                    updated_global.push_back(s.clone());
+                }
+            }
+            sel_list = updated_global;
+
+            env.storage()
+                .instance()
+                .remove(&DataKey::SelectorFacet(sel.clone()));
+        }
+
+        env.storage()
+            .instance()
+            .set(&DataKey::SelectorList, &sel_list);
+        env.storage()
+            .instance()
+            .set(&DataKey::FacetList, &facet_list);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Module-level helpers (pure Rust; no host calls)
+// ---------------------------------------------------------------------------
+
+fn addr_in_list(list: &Vec<Address>, addr: &Address) -> bool {
+    for a in list.iter() {
+        if &a == addr {
+            return true;
+        }
+    }
+    false
+}
+
+fn sym_in_list(list: &Vec<Symbol>, sym: &Symbol) -> bool {
+    for s in list.iter() {
+        if &s == sym {
+            return true;
+        }
+    }
+    false
+}
+
+// ---------------------------------------------------------------------------
+// TokenFacet — diamond storage namespace: Tf*
+// ---------------------------------------------------------------------------
+
+/// ERC-20-like token facet.
+///
+/// All state lives exclusively under `TfBalance`, `TfAllowance`, and
+/// `TfTotalSupply` DataKey variants. No other facet's keys can ever occupy
+/// those variants — this is the diamond storage isolation guarantee.
+#[contract]
+pub struct TokenFacet;
+
+#[contractimpl]
+impl TokenFacet {
+    /// Mint `amount` tokens to `to`, authorised by `minter`.
+    pub fn tf_mint(env: Env, minter: Address, to: Address, amount: i128) {
+        minter.require_auth();
+        assert!(amount > 0, "amount must be positive");
+
+        let bal: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::TfBalance(to.clone()))
+            .unwrap_or(0);
+        env.storage()
+            .persistent()
+            .set(&DataKey::TfBalance(to.clone()), &(bal + amount));
+
+        let supply: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::TfTotalSupply)
+            .unwrap_or(0);
+        env.storage()
+            .persistent()
+            .set(&DataKey::TfTotalSupply, &(supply + amount));
+
+        env.events()
+            .publish((NS_TOKEN, symbol_short!("mint"), to), amount);
+    }
+
+    /// Transfer `amount` tokens from `from` to `to`.
+    pub fn tf_transfer(env: Env, from: Address, to: Address, amount: i128) {
+        from.require_auth();
+        assert!(amount > 0, "amount must be positive");
+
+        let from_bal: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::TfBalance(from.clone()))
+            .unwrap_or(0);
+        assert!(from_bal >= amount, "insufficient balance");
+
+        let to_bal: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::TfBalance(to.clone()))
+            .unwrap_or(0);
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::TfBalance(from.clone()), &(from_bal - amount));
+        env.storage()
+            .persistent()
+            .set(&DataKey::TfBalance(to.clone()), &(to_bal + amount));
+
+        env.events()
+            .publish((NS_TOKEN, symbol_short!("transfer"), from, to), amount);
+    }
+
+    /// Approve `spender` to spend up to `amount` of `owner`'s tokens.
+    pub fn tf_approve(env: Env, owner: Address, spender: Address, amount: i128) {
+        owner.require_auth();
+        env.storage().persistent().set(
+            &DataKey::TfAllowance(owner.clone(), spender.clone()),
+            &amount,
+        );
+        env.events()
+            .publish((NS_TOKEN, symbol_short!("approve"), owner, spender), amount);
+    }
+
+    /// Transfer `amount` from `from` to `to` using a pre-approved allowance.
+    pub fn tf_transfer_from(env: Env, spender: Address, from: Address, to: Address, amount: i128) {
+        spender.require_auth();
+        let allowance: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::TfAllowance(from.clone(), spender.clone()))
+            .unwrap_or(0);
+        assert!(allowance >= amount, "allowance exceeded");
+
+        let from_bal: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::TfBalance(from.clone()))
+            .unwrap_or(0);
+        assert!(from_bal >= amount, "insufficient balance");
+
+        let to_bal: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::TfBalance(to.clone()))
+            .unwrap_or(0);
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::TfBalance(from.clone()), &(from_bal - amount));
+        env.storage()
+            .persistent()
+            .set(&DataKey::TfBalance(to.clone()), &(to_bal + amount));
+        env.storage()
+            .persistent()
+            .set(&DataKey::TfAllowance(from, spender), &(allowance - amount));
+    }
+
+    /// Return the token balance of `owner`.
+    pub fn tf_balance_of(env: Env, owner: Address) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::TfBalance(owner))
+            .unwrap_or(0)
+    }
+
+    /// Return the total token supply.
+    pub fn tf_total_supply(env: Env) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::TfTotalSupply)
+            .unwrap_or(0)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CounterFacet — diamond storage namespace: Cf*
+// ---------------------------------------------------------------------------
+
+/// Named counter facet.
+///
+/// Demonstrates a second, fully independent storage namespace (`CfCount`)
+/// that coexists with `TokenFacet`'s namespace (`Tf*`) in the same
+/// `DataKey` enum. Neither facet can accidentally read or overwrite the
+/// other's keys — the diamond storage pattern's isolation guarantee in action.
+#[contract]
+pub struct CounterFacet;
+
+#[contractimpl]
+impl CounterFacet {
+    /// Increment the named counter by 1.
+    pub fn cf_increment(env: Env, caller: Address, name: Symbol) {
+        caller.require_auth();
+        let count: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::CfCount(name.clone()))
+            .unwrap_or(0);
+        env.storage()
+            .persistent()
+            .set(&DataKey::CfCount(name.clone()), &(count + 1));
+        env.events()
+            .publish((NS_COUNTER, symbol_short!("inc"), caller, name), count + 1);
+    }
+
+    /// Reset the named counter back to zero.
+    pub fn cf_reset(env: Env, caller: Address, name: Symbol) {
+        caller.require_auth();
+        env.storage()
+            .persistent()
+            .set(&DataKey::CfCount(name.clone()), &0u32);
+        env.events()
+            .publish((NS_COUNTER, symbol_short!("reset"), caller, name), 0u32);
+    }
+
+    /// Return the current value of the named counter.
+    pub fn cf_get_count(env: Env, name: Symbol) -> u32 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::CfCount(name))
+            .unwrap_or(0)
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/examples/advanced/06-diamond-pattern/src/test.rs
+++ b/examples/advanced/06-diamond-pattern/src/test.rs
@@ -1,0 +1,519 @@
+#![cfg(test)]
+
+extern crate std;
+
+use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env, Vec};
+
+use crate::{
+    CounterFacet, CounterFacetClient, DiamondBase, DiamondBaseClient, FacetCut, FacetCutAction,
+    TokenFacet, TokenFacetClient,
+};
+
+// ---------------------------------------------------------------------------
+// Helper: register the three contracts and initialise the diamond
+// ---------------------------------------------------------------------------
+
+fn setup() -> (
+    Env,
+    Address,
+    DiamondBaseClient<'static>,
+    Address,
+    TokenFacetClient<'static>,
+    Address,
+    CounterFacetClient<'static>,
+) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let diamond_id = env.register(DiamondBase, ());
+    let token_id = env.register(TokenFacet, ());
+    let counter_id = env.register(CounterFacet, ());
+
+    let diamond = DiamondBaseClient::new(&env, &diamond_id);
+    let token = TokenFacetClient::new(&env, &token_id);
+    let counter = CounterFacetClient::new(&env, &counter_id);
+
+    let admin = Address::generate(&env);
+    diamond.initialize(&admin);
+
+    (env, admin, diamond, token_id, token, counter_id, counter)
+}
+
+// ---------------------------------------------------------------------------
+// DiamondBase — initialisation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_initialize_creates_empty_registry() {
+    let (_env, _admin, diamond, _tid, _token, _cid, _counter) = setup();
+    assert_eq!(diamond.selector_count(), 0);
+    assert_eq!(diamond.facet_addresses().len(), 0);
+}
+
+#[test]
+#[should_panic(expected = "already initialized")]
+fn test_double_initialize_panics() {
+    let (env, _admin, diamond, _tid, _token, _cid, _counter) = setup();
+    let other = Address::generate(&env);
+    diamond.initialize(&other);
+}
+
+// ---------------------------------------------------------------------------
+// Diamond cut — Add
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_diamond_cut_add_registers_selectors() {
+    let (env, admin, diamond, token_id, _token, _cid, _counter) = setup();
+
+    let mut cuts = Vec::new(&env);
+    let mut sels = Vec::new(&env);
+    sels.push_back(symbol_short!("tf_mint"));
+    sels.push_back(symbol_short!("tf_bal"));
+    cuts.push_back(FacetCut {
+        facet_address: token_id.clone(),
+        action: FacetCutAction::Add,
+        selectors: sels,
+    });
+    diamond.diamond_cut(&admin, &cuts);
+
+    assert_eq!(diamond.selector_count(), 2);
+    assert_eq!(
+        diamond.facet_address(&symbol_short!("tf_mint")),
+        Some(token_id.clone())
+    );
+    assert_eq!(
+        diamond.facet_address(&symbol_short!("tf_bal")),
+        Some(token_id)
+    );
+}
+
+#[test]
+fn test_diamond_cut_add_multiple_facets() {
+    let (env, admin, diamond, token_id, _token, counter_id, _counter) = setup();
+
+    let mut token_sels = Vec::new(&env);
+    token_sels.push_back(symbol_short!("tf_mint"));
+    token_sels.push_back(symbol_short!("tf_trsf"));
+
+    let mut counter_sels = Vec::new(&env);
+    counter_sels.push_back(symbol_short!("cf_inc"));
+    counter_sels.push_back(symbol_short!("cf_cnt"));
+
+    let mut cuts = Vec::new(&env);
+    cuts.push_back(FacetCut {
+        facet_address: token_id,
+        action: FacetCutAction::Add,
+        selectors: token_sels,
+    });
+    cuts.push_back(FacetCut {
+        facet_address: counter_id,
+        action: FacetCutAction::Add,
+        selectors: counter_sels,
+    });
+    diamond.diamond_cut(&admin, &cuts);
+
+    assert_eq!(diamond.selector_count(), 4);
+    assert_eq!(diamond.facet_addresses().len(), 2);
+}
+
+#[test]
+#[should_panic(expected = "selector already registered")]
+fn test_add_duplicate_selector_panics() {
+    let (env, admin, diamond, token_id, _token, _cid, _counter) = setup();
+
+    let mut sels = Vec::new(&env);
+    sels.push_back(symbol_short!("tf_mint"));
+
+    let mut cuts = Vec::new(&env);
+    cuts.push_back(FacetCut {
+        facet_address: token_id.clone(),
+        action: FacetCutAction::Add,
+        selectors: sels.clone(),
+    });
+    diamond.diamond_cut(&admin, &cuts);
+
+    // Adding the same selector again must panic.
+    let mut cuts2 = Vec::new(&env);
+    cuts2.push_back(FacetCut {
+        facet_address: token_id,
+        action: FacetCutAction::Add,
+        selectors: sels,
+    });
+    diamond.diamond_cut(&admin, &cuts2);
+}
+
+// ---------------------------------------------------------------------------
+// Diamond cut — Replace
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_diamond_cut_replace_remaps_selector() {
+    let (env, admin, diamond, token_id, _token, counter_id, _counter) = setup();
+
+    // Register under token facet first.
+    let mut sels = Vec::new(&env);
+    sels.push_back(symbol_short!("shared"));
+
+    let mut add_cuts = Vec::new(&env);
+    add_cuts.push_back(FacetCut {
+        facet_address: token_id.clone(),
+        action: FacetCutAction::Add,
+        selectors: sels.clone(),
+    });
+    diamond.diamond_cut(&admin, &add_cuts);
+    assert_eq!(
+        diamond.facet_address(&symbol_short!("shared")),
+        Some(token_id)
+    );
+
+    // Replace: now points to counter facet.
+    let mut replace_cuts = Vec::new(&env);
+    replace_cuts.push_back(FacetCut {
+        facet_address: counter_id.clone(),
+        action: FacetCutAction::Replace,
+        selectors: sels,
+    });
+    diamond.diamond_cut(&admin, &replace_cuts);
+    assert_eq!(
+        diamond.facet_address(&symbol_short!("shared")),
+        Some(counter_id)
+    );
+    // Total selector count stays the same.
+    assert_eq!(diamond.selector_count(), 1);
+}
+
+// ---------------------------------------------------------------------------
+// Diamond cut — Remove
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_diamond_cut_remove_deregisters_selector() {
+    let (env, admin, diamond, token_id, _token, _cid, _counter) = setup();
+
+    let mut sels = Vec::new(&env);
+    sels.push_back(symbol_short!("tf_mint"));
+    sels.push_back(symbol_short!("tf_bal"));
+
+    let mut add_cuts = Vec::new(&env);
+    add_cuts.push_back(FacetCut {
+        facet_address: token_id,
+        action: FacetCutAction::Add,
+        selectors: sels,
+    });
+    diamond.diamond_cut(&admin, &add_cuts);
+    assert_eq!(diamond.selector_count(), 2);
+
+    // Remove one selector.
+    let mut rm_sels = Vec::new(&env);
+    rm_sels.push_back(symbol_short!("tf_mint"));
+    let mut rm_cuts = Vec::new(&env);
+    rm_cuts.push_back(FacetCut {
+        facet_address: Address::generate(&env),
+        action: FacetCutAction::Remove,
+        selectors: rm_sels,
+    });
+    diamond.diamond_cut(&admin, &rm_cuts);
+
+    assert_eq!(diamond.selector_count(), 1);
+    assert_eq!(diamond.facet_address(&symbol_short!("tf_mint")), None);
+    assert!(diamond.facet_address(&symbol_short!("tf_bal")).is_some());
+}
+
+#[test]
+fn test_remove_last_selector_prunes_facet_from_list() {
+    let (env, admin, diamond, token_id, _token, _cid, _counter) = setup();
+
+    let mut sels = Vec::new(&env);
+    sels.push_back(symbol_short!("only_sel"));
+
+    let mut add_cuts = Vec::new(&env);
+    add_cuts.push_back(FacetCut {
+        facet_address: token_id.clone(),
+        action: FacetCutAction::Add,
+        selectors: sels.clone(),
+    });
+    diamond.diamond_cut(&admin, &add_cuts);
+    assert_eq!(diamond.facet_addresses().len(), 1);
+
+    // Removing the only selector should prune the facet from the list.
+    let mut rm_cuts = Vec::new(&env);
+    rm_cuts.push_back(FacetCut {
+        facet_address: Address::generate(&env),
+        action: FacetCutAction::Remove,
+        selectors: sels,
+    });
+    diamond.diamond_cut(&admin, &rm_cuts);
+
+    assert_eq!(diamond.facet_addresses().len(), 0);
+    assert_eq!(diamond.selector_count(), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Diamond loupe — introspection
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_loupe_facet_addresses() {
+    let (env, admin, diamond, token_id, _token, counter_id, _counter) = setup();
+
+    let mut token_sels = Vec::new(&env);
+    token_sels.push_back(symbol_short!("tf_mint"));
+    let mut counter_sels = Vec::new(&env);
+    counter_sels.push_back(symbol_short!("cf_inc"));
+
+    let mut cuts = Vec::new(&env);
+    cuts.push_back(FacetCut {
+        facet_address: token_id.clone(),
+        action: FacetCutAction::Add,
+        selectors: token_sels,
+    });
+    cuts.push_back(FacetCut {
+        facet_address: counter_id.clone(),
+        action: FacetCutAction::Add,
+        selectors: counter_sels,
+    });
+    diamond.diamond_cut(&admin, &cuts);
+
+    let addrs = diamond.facet_addresses();
+    assert_eq!(addrs.len(), 2);
+    assert!(addrs.contains(&token_id));
+    assert!(addrs.contains(&counter_id));
+}
+
+#[test]
+fn test_loupe_facet_function_selectors() {
+    let (env, admin, diamond, token_id, _token, _cid, _counter) = setup();
+
+    let mut sels = Vec::new(&env);
+    sels.push_back(symbol_short!("tf_mint"));
+    sels.push_back(symbol_short!("tf_trsf"));
+
+    let mut cuts = Vec::new(&env);
+    cuts.push_back(FacetCut {
+        facet_address: token_id.clone(),
+        action: FacetCutAction::Add,
+        selectors: sels,
+    });
+    diamond.diamond_cut(&admin, &cuts);
+
+    let facet_sels = diamond.facet_function_selectors(&token_id);
+    assert_eq!(facet_sels.len(), 2);
+    assert!(facet_sels.contains(&symbol_short!("tf_mint")));
+    assert!(facet_sels.contains(&symbol_short!("tf_trsf")));
+}
+
+#[test]
+fn test_loupe_facets_returns_complete_registry() {
+    let (env, admin, diamond, token_id, _token, counter_id, _counter) = setup();
+
+    let mut token_sels = Vec::new(&env);
+    token_sels.push_back(symbol_short!("tf_mint"));
+    let mut counter_sels = Vec::new(&env);
+    counter_sels.push_back(symbol_short!("cf_inc"));
+
+    let mut cuts = Vec::new(&env);
+    cuts.push_back(FacetCut {
+        facet_address: token_id,
+        action: FacetCutAction::Add,
+        selectors: token_sels,
+    });
+    cuts.push_back(FacetCut {
+        facet_address: counter_id,
+        action: FacetCutAction::Add,
+        selectors: counter_sels,
+    });
+    diamond.diamond_cut(&admin, &cuts);
+
+    let all_facets = diamond.facets();
+    assert_eq!(all_facets.len(), 2);
+}
+
+#[test]
+fn test_loupe_unknown_selector_returns_none() {
+    let (_env, _admin, diamond, _tid, _token, _cid, _counter) = setup();
+    assert_eq!(diamond.facet_address(&symbol_short!("nope")), None);
+}
+
+// ---------------------------------------------------------------------------
+// Fallback dispatch — resolving a facet and calling it directly
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_fallback_dispatch_via_facet_address() {
+    let (env, admin, diamond, token_id, token, _cid, _counter) = setup();
+
+    // Register the TokenFacet for the "tf_mint" selector.
+    let mut sels = Vec::new(&env);
+    sels.push_back(symbol_short!("tf_mint"));
+    let mut cuts = Vec::new(&env);
+    cuts.push_back(FacetCut {
+        facet_address: token_id.clone(),
+        action: FacetCutAction::Add,
+        selectors: sels,
+    });
+    diamond.diamond_cut(&admin, &cuts);
+
+    // Fallback mechanism: resolve the facet for "tf_mint".
+    let resolved = diamond
+        .facet_address(&symbol_short!("tf_mint"))
+        .expect("selector not registered");
+    assert_eq!(resolved, token_id);
+
+    // Dispatch to the resolved facet.
+    let minter = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    token.tf_mint(&minter, &recipient, &750i128);
+
+    assert_eq!(token.tf_balance_of(&recipient), 750);
+    assert_eq!(token.tf_total_supply(), 750);
+}
+
+// ---------------------------------------------------------------------------
+// TokenFacet
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_token_mint_and_balance() {
+    let (env, _admin, _diamond, _tid, token, _cid, _counter) = setup();
+    let minter = Address::generate(&env);
+    let recipient = Address::generate(&env);
+
+    token.tf_mint(&minter, &recipient, &1_000i128);
+
+    assert_eq!(token.tf_balance_of(&recipient), 1_000);
+    assert_eq!(token.tf_total_supply(), 1_000);
+}
+
+#[test]
+fn test_token_transfer_updates_balances() {
+    let (env, _admin, _diamond, _tid, token, _cid, _counter) = setup();
+    let minter = Address::generate(&env);
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+
+    token.tf_mint(&minter, &alice, &500i128);
+    token.tf_transfer(&alice, &bob, &200i128);
+
+    assert_eq!(token.tf_balance_of(&alice), 300);
+    assert_eq!(token.tf_balance_of(&bob), 200);
+    assert_eq!(token.tf_total_supply(), 500);
+}
+
+#[test]
+#[should_panic(expected = "insufficient balance")]
+fn test_token_transfer_insufficient_balance_panics() {
+    let (env, _admin, _diamond, _tid, token, _cid, _counter) = setup();
+    let minter = Address::generate(&env);
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+
+    token.tf_mint(&minter, &alice, &100i128);
+    token.tf_transfer(&alice, &bob, &200i128);
+}
+
+#[test]
+fn test_token_approve_and_transfer_from() {
+    let (env, _admin, _diamond, _tid, token, _cid, _counter) = setup();
+    let minter = Address::generate(&env);
+    let owner = Address::generate(&env);
+    let spender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+
+    token.tf_mint(&minter, &owner, &1_000i128);
+    token.tf_approve(&owner, &spender, &400i128);
+    token.tf_transfer_from(&spender, &owner, &recipient, &300i128);
+
+    assert_eq!(token.tf_balance_of(&owner), 700);
+    assert_eq!(token.tf_balance_of(&recipient), 300);
+}
+
+#[test]
+#[should_panic(expected = "allowance exceeded")]
+fn test_token_transfer_from_exceeds_allowance_panics() {
+    let (env, _admin, _diamond, _tid, token, _cid, _counter) = setup();
+    let minter = Address::generate(&env);
+    let owner = Address::generate(&env);
+    let spender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+
+    token.tf_mint(&minter, &owner, &1_000i128);
+    token.tf_approve(&owner, &spender, &100i128);
+    token.tf_transfer_from(&spender, &owner, &recipient, &500i128);
+}
+
+// ---------------------------------------------------------------------------
+// CounterFacet
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_counter_increment_and_get() {
+    let (env, _admin, _diamond, _tid, _token, _cid, counter) = setup();
+    let caller = Address::generate(&env);
+    let name = symbol_short!("hits");
+
+    counter.cf_increment(&caller, &name);
+    counter.cf_increment(&caller, &name);
+    counter.cf_increment(&caller, &name);
+
+    assert_eq!(counter.cf_get_count(&name), 3);
+}
+
+#[test]
+fn test_counter_reset_returns_to_zero() {
+    let (env, _admin, _diamond, _tid, _token, _cid, counter) = setup();
+    let caller = Address::generate(&env);
+    let name = symbol_short!("clicks");
+
+    counter.cf_increment(&caller, &name);
+    counter.cf_increment(&caller, &name);
+    assert_eq!(counter.cf_get_count(&name), 2);
+
+    counter.cf_reset(&caller, &name);
+    assert_eq!(counter.cf_get_count(&name), 0);
+}
+
+#[test]
+fn test_counter_independent_names_do_not_interfere() {
+    let (env, _admin, _diamond, _tid, _token, _cid, counter) = setup();
+    let caller = Address::generate(&env);
+
+    counter.cf_increment(&caller, &symbol_short!("pageA"));
+    counter.cf_increment(&caller, &symbol_short!("pageA"));
+    counter.cf_increment(&caller, &symbol_short!("pageB"));
+
+    assert_eq!(counter.cf_get_count(&symbol_short!("pageA")), 2);
+    assert_eq!(counter.cf_get_count(&symbol_short!("pageB")), 1);
+}
+
+// ---------------------------------------------------------------------------
+// Diamond storage pattern — cross-facet namespace isolation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_storage_namespaces_do_not_collide() {
+    // TfBalance(address) and CfCount(symbol) live in different DataKey variants;
+    // writes to one can never bleed into the other.
+    let (env, _admin, _diamond, _tid, token, _cid, counter) = setup();
+    let minter = Address::generate(&env);
+    let user = Address::generate(&env);
+    let name = symbol_short!("views");
+
+    token.tf_mint(&minter, &user, &5_000i128);
+    counter.cf_increment(&user, &name);
+    counter.cf_increment(&user, &name);
+
+    assert_eq!(token.tf_balance_of(&user), 5_000);
+    assert_eq!(counter.cf_get_count(&name), 2);
+
+    // Resetting the counter must not affect the token balance.
+    counter.cf_reset(&user, &name);
+    assert_eq!(counter.cf_get_count(&name), 0);
+    assert_eq!(token.tf_balance_of(&user), 5_000);
+
+    // Transferring tokens must not affect the counter.
+    let recipient = Address::generate(&env);
+    token.tf_transfer(&user, &recipient, &1_000i128);
+    assert_eq!(counter.cf_get_count(&name), 0);
+    assert_eq!(token.tf_balance_of(&user), 4_000);
+}


### PR DESCRIPTION
## Description

This PR implements the diamond pattern base (EIP-2535 equivalent) for Soroban, resolving issue #562. Because Soroban lacks `delegatecall`, the EIP-2535 concepts are adapted to the Soroban execution model while preserving every architectural guarantee the standard provides.

The example lives at `examples/advanced/06-diamond-pattern/` (numbered 06 to avoid a naming conflict with the existing `01-multi-party-auth` directory, as the issue was written before the advanced section had its current entries).

## Type of Change

- [x] New example or improvement to existing example

## Related Issues

Closes #562

## Changes Made

- Added `DiamondBase` contract implementing:
  - `initialize(admin)` — single-call bootstrap
  - `diamond_cut(admin, cuts)` — batched Add / Replace / Remove selector operations
  - `facet_address(selector)` — fallback dispatch entry point
  - `facets()`, `facet_addresses()`, `facet_function_selectors(facet)`, `selector_count()` — full diamond-loupe introspection
- Added `TokenFacet` — ERC-20-like token facet demonstrating the `Tf*` storage namespace
- Added `CounterFacet` — named-counter facet demonstrating the independent `Cf*` storage namespace
- The shared `DataKey` enum is the Soroban realisation of the EIP-2535 diamond storage pattern: variant tags act as per-facet namespace prefixes, guaranteeing storage isolation without hash slots
- Added `Cargo.toml` using workspace inheritance
- Added `README.md` with architecture diagram, concept explanations, and security considerations
- 22 unit tests covering all acceptance criteria

## Testing

### Test Steps

1. `cargo fmt --all --check`
2. `cargo clippy -p diamond-pattern --all-targets -- -D warnings`
3. `cargo test -p diamond-pattern`
4. `cargo build --target wasm32v1-none --release -p diamond-pattern`

### Test Results

```
running 22 tests
test test::test_counter_increment_and_get ... ok
test test::test_counter_independent_names_do_not_interfere ... ok
test test::test_counter_reset_returns_to_zero ... ok
test test::test_diamond_cut_add_registers_selectors ... ok
test test::test_add_duplicate_selector_panics - should panic ... ok
test test::test_initialize_creates_empty_registry ... ok
test test::test_fallback_dispatch_via_facet_address ... ok
test test::test_double_initialize_panics - should panic ... ok
test test::test_diamond_cut_replace_remaps_selector ... ok
test test::test_diamond_cut_remove_deregisters_selector ... ok
test test::test_diamond_cut_add_multiple_facets ... ok
test test::test_loupe_facet_addresses ... ok
test test::test_loupe_unknown_selector_returns_none ... ok
test test::test_remove_last_selector_prunes_facet_from_list ... ok
test test::test_loupe_facet_function_selectors ... ok
test test::test_loupe_facets_returns_complete_registry ... ok
test test::test_token_transfer_insufficient_balance_panics - should panic ... ok
test test::test_token_approve_and_transfer_from ... ok
test test::test_token_mint_and_balance ... ok
test test::test_storage_namespaces_do_not_collide ... ok
test test::test_token_transfer_from_exceeds_allowance_panics - should panic ... ok
test test::test_token_transfer_updates_balances ... ok

test result: ok. 22 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

> Note: the WASM build uses `wasm32v1-none` rather than `wasm32-unknown-unknown` because the Soroban SDK 26.x requires this target on Rust 1.84+.

## Checklist

### Code Quality
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] All contracts use `#![no_std]`
- [x] Custom errors use `#[contracterror]` where applicable

### Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

### Documentation
- [x] I have added/updated the example's README.md

### Pre-submission Validation
- [x] Code formatting passes: `cargo fmt --all --check`
- [x] Linting passes with no warnings: `cargo clippy -p diamond-pattern --all-targets -- -D warnings`
- [x] All tests pass: `cargo test -p diamond-pattern` (22/22)
- [x] WASM build succeeds: `cargo build --target wasm32v1-none --release -p diamond-pattern`

### Other
- [x] I have read the contributing guidelines