### PR TITLE
feat: implement issues 602, 603, 608, and 609

### DIFF
--- a/COMMUNITY_GUIDELINES.md
+++ b/COMMUNITY_GUIDELINES.md
@@ -1,0 +1,71 @@
+# Community Guidelines
+
+Welcome to the Soroban Cookbook community. These guidelines exist to keep our spaces welcoming, productive, and safe for everyone.
+
+## Our Values
+
+- **Openness** — We welcome contributors of all backgrounds and experience levels.
+- **Respect** — We treat every person with dignity in every interaction.
+- **Collaboration** — We share knowledge freely and help each other grow.
+- **Quality** — We take pride in correct, well-tested, clearly documented work.
+
+## Participation Standards
+
+### What we encourage
+
+- Asking questions, no matter how basic they may seem.
+- Giving and receiving constructive feedback on code and documentation.
+- Sharing real-world usage patterns, gotchas, and lessons learned.
+- Helping newcomers find their footing in the Soroban ecosystem.
+- Linking to upstream Stellar or Soroban resources when relevant.
+
+### What is not acceptable
+
+- Harassment, intimidation, or personal attacks of any kind.
+- Discriminatory language or behaviour related to age, disability, ethnicity, gender identity, nationality, religion, sexual orientation, or any other personal characteristic.
+- Publishing private information (contact details, location, etc.) of others without consent.
+- Spam, off-topic promotion, or low-effort contributions intended only to game metrics.
+- Deliberately submitting broken, insecure, or plagiarised code as original work.
+
+These standards apply in all community spaces: GitHub issues, pull requests, code review comments, discussions, Discord channels, and any public forum where the cookbook is represented.
+
+## Code of Conduct
+
+This project is governed by the [Contributor Covenant Code of Conduct](./CODE_OF_CONDUCT.md). All community members are expected to uphold it. The Code of Conduct describes our standards in detail and the escalating enforcement actions available to maintainers.
+
+## Reporting Unacceptable Behaviour
+
+If you witness or experience behaviour that violates these guidelines or the Code of Conduct, please report it through one of the following channels:
+
+1. **GitHub** — Open a [confidential issue](https://github.com/Soroban-Cookbook/Soroban-Cookbook-/issues) labelled `conduct` or contact a maintainer directly via GitHub.
+2. **Email** — Reach the maintainer team at **maintainers@sorobancookbook.dev**.
+
+All reports are reviewed promptly and in confidence. The identity of the reporter will not be shared without explicit consent.
+
+## Enforcement
+
+Maintainers are responsible for clarifying and enforcing these guidelines. Upon receiving a report, they will:
+
+1. Acknowledge the report within **two business days**.
+2. Review the incident privately with the relevant maintainers.
+3. Determine an appropriate response according to the severity levels below.
+4. Communicate the outcome to the reporter.
+
+### Severity levels and consequences
+
+| Level | Behaviour | Consequence |
+| ----- | --------- | ----------- |
+| 1 — Correction | Isolated inappropriate language or minor misconduct | Private written warning; public apology may be requested |
+| 2 — Warning | Pattern of minor violations or a single significant incident | Formal warning; temporary restriction from community spaces |
+| 3 — Temporary ban | Serious violation or sustained disruptive behaviour | Temporary ban from all community interaction |
+| 4 — Permanent ban | Repeated severe violations or targeted harassment | Permanent removal from all community spaces |
+
+Maintainers exercise judgement in applying these levels; the table is a guide, not a rigid formula.
+
+## Contributing
+
+Before submitting a pull request, please review [CONTRIBUTING.md](./CONTRIBUTING.md) for technical requirements and workflow expectations.
+
+## Acknowledgements
+
+These guidelines are informed by the [Contributor Covenant](https://www.contributor-covenant.org/) and the practices of other open-source communities in the Rust and Stellar ecosystems.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 # Contributing to Soroban-Cookbook
 
+Before participating, please read our [Community Guidelines](./COMMUNITY_GUIDELINES.md) and [Code of Conduct](./CODE_OF_CONDUCT.md).
+
 ## Feedback System
 
 We have implemented a comprehensive feedback system to collect and manage input from our community. The system is located in the `docs/feedback-system/` directory.

--- a/book/src/README.md
+++ b/book/src/README.md
@@ -4,52 +4,132 @@
 
 ## About
 
-The Soroban Cookbook is a developer's guide to building smart contracts on the Stellar network using Soroban. This documentation provides clear, well-documented examples and practical patterns for developers at every level—from your first "Hello World" contract to complex DeFi protocols.
-
-## What You'll Find Here
-
-### Examples by Difficulty
-
-- **Basics** - Core concepts: storage, auth, events, and data types
-- **Intermediate** - Tokens, NFTs, multi-contract interactions
-- **Advanced** - DeFi protocols, governance systems, cross-chain patterns
-
-### Examples by Use Case
-
-- **DeFi** - AMMs, lending, vaults, escrow, and yield protocols
-- **NFTs** - Minting, marketplaces, and metadata standards
-- **Governance** - DAOs, voting systems, and proposals
-- **Tokens** - Custom tokens, wrappers, and token standards
-
-## Video Walkthrough
-
-> **Getting Started — Examples 01–03** *(coming soon)*
-> A 10–15 minute video covering Hello World, Storage Patterns, and Custom Errors.
-> Subscribe to be notified when it's published, or check the
-> [Soroban Cookbook YouTube channel](https://www.youtube.com/@SorobanCookbook) directly.
->
-> Once published, the link will appear here and in each example's README.
+The Soroban Cookbook is a developer's guide to building smart contracts on the Stellar network using Soroban. This documentation provides clear, well-documented examples and practical patterns for developers at every level — from your first "Hello World" contract to complex DeFi protocols.
 
 ## Quick Start
 
 ```bash
-# Install Rust and Soroban CLI
+# Install Rust
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-cargo install --locked soroban-cli
+source "$HOME/.cargo/env"
+
+# Add WebAssembly target
+rustup target add wasm32-unknown-unknown
+
+# Install Stellar CLI
+cargo install --locked stellar-cli --version 22.1.0
 
 # Clone the repository
-git clone https://github.com/Soroban-Cookbook/Soroban-Cookbook.git
-cd Soroban-Cookbook
+git clone https://github.com/Soroban-Cookbook/Soroban-Cookbook-.git
+cd Soroban-Cookbook-
 
-# Try a basic example
+# Run a basic example
 cd examples/basics/01-hello-world
 cargo test
-soroban contract build
 ```
+
+## Repository Structure
+
+```
+Soroban-Cookbook/
+├── examples/               # Smart contract examples
+│   ├── basics/             # Beginner-friendly fundamentals
+│   ├── intermediate/       # Common patterns and use cases
+│   ├── advanced/           # Complex systems and protocols
+│   ├── defi/               # DeFi-specific examples
+│   ├── nfts/               # NFT implementations
+│   ├── governance/         # DAO and voting systems
+│   └── tokens/             # Token standards and patterns
+├── book/                   # mdBook documentation source
+│   └── src/
+│       ├── guides/         # Step-by-step tutorials
+│       ├── examples/       # Example write-ups
+│       └── docs/           # Reference documentation
+├── tests/                  # Integration and security tests
+└── scripts/                # Build and deployment scripts
+```
+
+## Examples by Difficulty
+
+### Basics
+
+Core Soroban concepts, one at a time.
+
+| Example | Concepts |
+| --- | --- |
+| [01-hello-world](../examples/basics/01-hello-world/) | Contract struct, `#[contract]` / `#[contractimpl]`, unit tests |
+| [02-storage-patterns](../examples/basics/02-storage-patterns/) | `persistent`, `instance`, `temporary` storage, TTL |
+| [03-authentication](../examples/basics/03-authentication/) | `require_auth()`, admin roles, balances |
+| [03-custom-errors](../examples/basics/03-custom-errors/) | `#[contracterror]`, error codes |
+| [04-events](../examples/basics/04-events/) | `env.events().publish()`, topic design |
+| [05-error-handling](../examples/basics/05-error-handling/) | Error enums, validation, propagation |
+| [06-validation-patterns](../examples/basics/06-validation-patterns/) | Precondition checks, overflow-safe arithmetic |
+| [07-type-conversions](../examples/basics/07-type-conversions/) | `TryFromVal`, `IntoVal`, safe narrowing |
+| [08-soroban-types](../examples/basics/08-soroban-types/) | `Address`, `Symbol`, `Bytes`, `Map`, `Vec` |
+| [09-enum-types](../examples/basics/09-enum-types/) | `#[contracttype]` enums, role dispatch |
+| [10-custom-structs](../examples/basics/10-custom-structs/) | `#[contracttype]` structs, nested types |
+| [11-primitive-types](../examples/basics/11-primitive-types/) | `u32`, `u64`, `i128`, arithmetic safety |
+| [12-data-types](../examples/basics/12-data-types/) | Full type system reference |
+| [13-collection-types](../examples/basics/13-collection-types/) | `Vec`, `Map` collection patterns |
+
+### Intermediate
+
+Common patterns and real-world use cases.
+
+- Cross-contract patterns: factory, proxy, registry
+- Access control: multi-sig patterns, RBAC, timelocks
+- Token interactions and wrappers
+
+### Advanced
+
+Complex systems for experienced developers.
+
+| Example | Concepts |
+| --- | --- |
+| [01-multi-party-auth](../examples/advanced/01-multi-party-auth/) | Threshold signatures, multi-party authorization |
+| [02-timelock](../examples/advanced/02-timelock/) | Time-delayed execution, queue/cancel/execute |
+
+## Examples by Use Case
+
+| Category | Description |
+| --- | --- |
+| DeFi | AMMs, lending pools, vaults, escrow, yield protocols |
+| NFTs | Minting, marketplaces, metadata standards |
+| Governance | DAOs, voting systems, proposals |
+| Tokens | SEP-41 tokens, wrappers, vesting, airdrops |
+
+## Guides
+
+| Guide | Description |
+| --- | --- |
+| [Getting Started](./guides/getting-started.md) | Set up your development environment |
+| [Testing](./guides/testing.md) | Unit tests, integration tests, best practices |
+| [Deployment](./guides/deployment.md) | Deploy to testnet and mainnet |
+| [Local Simulation](./guides/local-simulation.md) | Run contracts locally with the Stellar CLI |
+| [Ethereum to Soroban](./guides/ethereum-to-soroban.md) | Solidity → Rust pattern translation |
+
+## API Reference
+
+| Document | Description |
+| --- | --- |
+| [Quick Reference](./docs/quick-reference.md) | Cheat sheet for common patterns |
+| [Best Practices](./docs/best-practices.md) | Security, storage, and code quality guidelines |
+| [Common Pitfalls](./docs/common-pitfalls.md) | Mistakes to avoid |
+| [Glossary](./docs/glossary.md) | Key terms and concepts |
+| [Troubleshooting](./docs/troubleshooting.md) | Common build, test, and deployment issues |
+
+## Code Quality Standards
+
+Every example in this cookbook:
+
+- Compiles successfully using the latest stable Soroban SDK
+- Contains comprehensive unit and integration tests
+- Enforces strict security boundaries and Rust/Soroban best practices
+- Passes all CI/CD pipelines including formatting, Clippy, and test suites
 
 ## Contributing
 
-Contributions are welcome. Whether you're fixing a typo, improving docs, or adding a new example — see [CONTRIBUTING.md](./CONTRIBUTING.md) for guidelines. Please also read our [Code of Conduct](./CODE_OF_CONDUCT.md).
+Contributions are welcome. See [CONTRIBUTING.md](./CONTRIBUTING.md) for guidelines and [Community Guidelines](./community-guidelines.md) for participation norms. Please also read our [Code of Conduct](./CODE_OF_CONDUCT.md).
 
 ## Additional Resources
 

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -6,6 +6,9 @@
 
 - [Setup Environment](./guides/getting-started.md)
 - [macOS Setup Guide](./guides/macos-setup.md)
+
+# Guides
+
 - [Testing Guide](./guides/testing.md)
 - [Local Simulation](./guides/local-simulation.md)
 - [Deployment Guide](./guides/deployment.md)
@@ -48,7 +51,7 @@
 ## Tokens
 - [Overview & planned](./examples/tokens.md)
 
-# Reference
+# API Reference
 
 - [Quick Reference](./docs/quick-reference.md)
 - [Best Practices](./docs/best-practices.md)
@@ -66,9 +69,9 @@
 - [Wallet Ecosystem Survey](./docs/wallet-ecosystem.md)
 - [Security Best Practices](./docs/security-best-practices.md)
 
+# Community
 
-# Contributing
-
+- [Community Guidelines](./community-guidelines.md)
 - [How to Contribute](./CONTRIBUTING.md)
 - [Code of Conduct](./CODE_OF_CONDUCT.md)
 

--- a/book/src/community-guidelines.md
+++ b/book/src/community-guidelines.md
@@ -1,0 +1,71 @@
+# Community Guidelines
+
+Welcome to the Soroban Cookbook community. These guidelines exist to keep our spaces welcoming, productive, and safe for everyone.
+
+## Our Values
+
+- **Openness** — We welcome contributors of all backgrounds and experience levels.
+- **Respect** — We treat every person with dignity in every interaction.
+- **Collaboration** — We share knowledge freely and help each other grow.
+- **Quality** — We take pride in correct, well-tested, clearly documented work.
+
+## Participation Standards
+
+### What we encourage
+
+- Asking questions, no matter how basic they may seem.
+- Giving and receiving constructive feedback on code and documentation.
+- Sharing real-world usage patterns, gotchas, and lessons learned.
+- Helping newcomers find their footing in the Soroban ecosystem.
+- Linking to upstream Stellar or Soroban resources when relevant.
+
+### What is not acceptable
+
+- Harassment, intimidation, or personal attacks of any kind.
+- Discriminatory language or behaviour related to age, disability, ethnicity, gender identity, nationality, religion, sexual orientation, or any other personal characteristic.
+- Publishing private information (contact details, location, etc.) of others without consent.
+- Spam, off-topic promotion, or low-effort contributions intended only to game metrics.
+- Deliberately submitting broken, insecure, or plagiarised code as original work.
+
+These standards apply in all community spaces: GitHub issues, pull requests, code review comments, discussions, Discord channels, and any public forum where the cookbook is represented.
+
+## Code of Conduct
+
+This project is governed by the [Contributor Covenant Code of Conduct](./CODE_OF_CONDUCT.md). All community members are expected to uphold it. The Code of Conduct describes our standards in detail and the escalating enforcement actions available to maintainers.
+
+## Reporting Unacceptable Behaviour
+
+If you witness or experience behaviour that violates these guidelines or the Code of Conduct, please report it through one of the following channels:
+
+1. **GitHub** — Open a [confidential issue](https://github.com/Soroban-Cookbook/Soroban-Cookbook-/issues) labelled `conduct` or contact a maintainer directly via GitHub.
+2. **Email** — Reach the maintainer team at **maintainers@sorobancookbook.dev**.
+
+All reports are reviewed promptly and in confidence. The identity of the reporter will not be shared without explicit consent.
+
+## Enforcement
+
+Maintainers are responsible for clarifying and enforcing these guidelines. Upon receiving a report, they will:
+
+1. Acknowledge the report within **two business days**.
+2. Review the incident privately with the relevant maintainers.
+3. Determine an appropriate response according to the severity levels below.
+4. Communicate the outcome to the reporter.
+
+### Severity levels and consequences
+
+| Level | Behaviour | Consequence |
+| ----- | --------- | ----------- |
+| 1 — Correction | Isolated inappropriate language or minor misconduct | Private written warning; public apology may be requested |
+| 2 — Warning | Pattern of minor violations or a single significant incident | Formal warning; temporary restriction from community spaces |
+| 3 — Temporary ban | Serious violation or sustained disruptive behaviour | Temporary ban from all community interaction |
+| 4 — Permanent ban | Repeated severe violations or targeted harassment | Permanent removal from all community spaces |
+
+Maintainers exercise judgement in applying these levels; the table is a guide, not a rigid formula.
+
+## Contributing
+
+Before submitting a pull request, please review [CONTRIBUTING.md](./CONTRIBUTING.md) for technical requirements and workflow expectations.
+
+## Acknowledgements
+
+These guidelines are informed by the [Contributor Covenant](https://www.contributor-covenant.org/) and the practices of other open-source communities in the Rust and Stellar ecosystems.

--- a/tests/integration/tests/fuzz_tests.rs
+++ b/tests/integration/tests/fuzz_tests.rs
@@ -1,0 +1,367 @@
+//! Fuzz / boundary tests for basic example contracts.
+//!
+//! Each test targets a specific edge case or boundary condition rather than
+//! the happy path already covered in integration_tests.rs.
+
+#![cfg(not(target_arch = "wasm32"))]
+#![cfg(test)]
+
+use soroban_sdk::{
+    symbol_short, testutils::Address as _, Address, Env, IntoVal, Symbol, Vec,
+};
+
+// ---------------------------------------------------------------------------
+// Storage — boundary values
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fuzz_storage_max_u64_persistent() {
+    let env = Env::default();
+    let id = env.register_contract(None, storage_patterns::StorageContract);
+    let key = symbol_short!("maxkey");
+
+    env.invoke_contract::<()>(
+        &id,
+        &Symbol::new(&env, "set_persistent"),
+        Vec::from_array(&env, [key.into_val(&env), u64::MAX.into_val(&env)]),
+    );
+
+    let val: Option<u64> = env.invoke_contract(
+        &id,
+        &Symbol::new(&env, "get_persistent"),
+        Vec::from_array(&env, [key.into_val(&env)]),
+    );
+    assert_eq!(val, Some(u64::MAX));
+}
+
+#[test]
+fn fuzz_storage_zero_u64_persistent() {
+    let env = Env::default();
+    let id = env.register_contract(None, storage_patterns::StorageContract);
+    let key = symbol_short!("zerokey");
+
+    env.invoke_contract::<()>(
+        &id,
+        &Symbol::new(&env, "set_persistent"),
+        Vec::from_array(&env, [key.into_val(&env), 0u64.into_val(&env)]),
+    );
+
+    let val: Option<u64> = env.invoke_contract(
+        &id,
+        &Symbol::new(&env, "get_persistent"),
+        Vec::from_array(&env, [key.into_val(&env)]),
+    );
+    assert_eq!(val, Some(0));
+}
+
+#[test]
+fn fuzz_storage_overwrite_three_times() {
+    let env = Env::default();
+    let id = env.register_contract(None, storage_patterns::StorageContract);
+    let key = symbol_short!("ovkey");
+
+    for value in [100u64, 200u64, 300u64] {
+        env.invoke_contract::<()>(
+            &id,
+            &Symbol::new(&env, "set_persistent"),
+            Vec::from_array(&env, [key.into_val(&env), value.into_val(&env)]),
+        );
+    }
+
+    let val: Option<u64> = env.invoke_contract(
+        &id,
+        &Symbol::new(&env, "get_persistent"),
+        Vec::from_array(&env, [key.into_val(&env)]),
+    );
+    assert_eq!(val, Some(300));
+}
+
+#[test]
+fn fuzz_storage_max_u64_temporary() {
+    let env = Env::default();
+    let id = env.register_contract(None, storage_patterns::StorageContract);
+    let key = symbol_short!("tmaxkey");
+
+    env.invoke_contract::<()>(
+        &id,
+        &Symbol::new(&env, "set_temporary"),
+        Vec::from_array(&env, [key.into_val(&env), u64::MAX.into_val(&env)]),
+    );
+
+    let val: Option<u64> = env.invoke_contract(
+        &id,
+        &Symbol::new(&env, "get_temporary"),
+        Vec::from_array(&env, [key.into_val(&env)]),
+    );
+    assert_eq!(val, Some(u64::MAX));
+}
+
+#[test]
+fn fuzz_storage_missing_key_returns_none() {
+    let env = Env::default();
+    let id = env.register_contract(None, storage_patterns::StorageContract);
+    let key = symbol_short!("absent");
+
+    let val: Option<u64> = env.invoke_contract(
+        &id,
+        &Symbol::new(&env, "get_persistent"),
+        Vec::from_array(&env, [key.into_val(&env)]),
+    );
+    assert_eq!(val, None);
+
+    let has: bool = env.invoke_contract(
+        &id,
+        &Symbol::new(&env, "has_persistent"),
+        Vec::from_array(&env, [key.into_val(&env)]),
+    );
+    assert!(!has);
+}
+
+// ---------------------------------------------------------------------------
+// Authentication — transfer boundary cases
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fuzz_auth_transfer_entire_balance() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let id = env.register_contract(None, authentication::AuthContract);
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let receiver = Address::generate(&env);
+
+    env.invoke_contract::<()>(
+        &id,
+        &Symbol::new(&env, "initialize"),
+        Vec::from_array(&env, [admin.clone().into_val(&env)]),
+    );
+    env.invoke_contract::<()>(
+        &id,
+        &Symbol::new(&env, "set_balance"),
+        Vec::from_array(
+            &env,
+            [
+                admin.clone().into_val(&env),
+                sender.clone().into_val(&env),
+                100i128.into_val(&env),
+            ],
+        ),
+    );
+
+    env.invoke_contract::<()>(
+        &id,
+        &symbol_short!("transfer"),
+        Vec::from_array(
+            &env,
+            [
+                sender.clone().into_val(&env),
+                receiver.clone().into_val(&env),
+                100i128.into_val(&env),
+            ],
+        ),
+    );
+
+    let sender_bal: i128 = env.invoke_contract(
+        &id,
+        &Symbol::new(&env, "get_balance"),
+        Vec::from_array(&env, [sender.into_val(&env)]),
+    );
+    let receiver_bal: i128 = env.invoke_contract(
+        &id,
+        &Symbol::new(&env, "get_balance"),
+        Vec::from_array(&env, [receiver.into_val(&env)]),
+    );
+
+    assert_eq!(sender_bal, 0);
+    assert_eq!(receiver_bal, 100);
+}
+
+#[test]
+fn fuzz_auth_many_small_transfers() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let id = env.register_contract(None, authentication::AuthContract);
+    let admin = Address::generate(&env);
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+
+    env.invoke_contract::<()>(
+        &id,
+        &Symbol::new(&env, "initialize"),
+        Vec::from_array(&env, [admin.clone().into_val(&env)]),
+    );
+    env.invoke_contract::<()>(
+        &id,
+        &Symbol::new(&env, "set_balance"),
+        Vec::from_array(
+            &env,
+            [
+                admin.clone().into_val(&env),
+                alice.clone().into_val(&env),
+                50i128.into_val(&env),
+            ],
+        ),
+    );
+
+    for _ in 0..5 {
+        env.invoke_contract::<()>(
+            &id,
+            &symbol_short!("transfer"),
+            Vec::from_array(
+                &env,
+                [
+                    alice.clone().into_val(&env),
+                    bob.clone().into_val(&env),
+                    1i128.into_val(&env),
+                ],
+            ),
+        );
+    }
+
+    let alice_bal: i128 = env.invoke_contract(
+        &id,
+        &Symbol::new(&env, "get_balance"),
+        Vec::from_array(&env, [alice.into_val(&env)]),
+    );
+    let bob_bal: i128 = env.invoke_contract(
+        &id,
+        &Symbol::new(&env, "get_balance"),
+        Vec::from_array(&env, [bob.into_val(&env)]),
+    );
+
+    assert_eq!(alice_bal, 45);
+    assert_eq!(bob_bal, 5);
+}
+
+// ---------------------------------------------------------------------------
+// Error handling — deposit/withdraw boundary cases
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fuzz_error_handling_minimum_deposit() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let id = env.register_contract(None, error_handling::ErrorDemoContract);
+    let client = error_handling::ErrorDemoContractClient::new(&env, &id);
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    client.initialize(&admin);
+
+    let bal = client.deposit(&user, &1i128);
+    assert_eq!(bal, 1);
+    assert_eq!(client.balance(&user), 1);
+}
+
+#[test]
+fn fuzz_error_handling_exact_withdraw_boundary() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let id = env.register_contract(None, error_handling::ErrorDemoContract);
+    let client = error_handling::ErrorDemoContractClient::new(&env, &id);
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    client.initialize(&admin);
+
+    client.deposit(&user, &500i128);
+    client.withdraw(&user, &499i128);
+    assert_eq!(client.balance(&user), 1);
+
+    let final_bal = client.withdraw(&user, &1i128);
+    assert_eq!(final_bal, 0);
+    assert_eq!(client.balance(&user), 0);
+}
+
+#[test]
+fn fuzz_error_handling_consecutive_deposits_accumulate() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let id = env.register_contract(None, error_handling::ErrorDemoContract);
+    let client = error_handling::ErrorDemoContractClient::new(&env, &id);
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    client.initialize(&admin);
+
+    client.deposit(&user, &100i128);
+    client.deposit(&user, &200i128);
+    client.deposit(&user, &300i128);
+
+    assert_eq!(client.balance(&user), 600);
+}
+
+#[test]
+fn fuzz_error_handling_overdraft_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let id = env.register_contract(None, error_handling::ErrorDemoContract);
+    let client = error_handling::ErrorDemoContractClient::new(&env, &id);
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    client.initialize(&admin);
+
+    client.deposit(&user, &100i128);
+
+    let err = client.try_withdraw(&user, &101i128);
+    assert_eq!(
+        err,
+        Err(Ok(error_handling::ContractError::InsufficientBalance))
+    );
+
+    assert_eq!(client.balance(&user), 100);
+}
+
+// ---------------------------------------------------------------------------
+// Custom errors — input validation boundary cases
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fuzz_custom_errors_zero_input_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let id = env.register_contract(None, custom_errors::CustomErrorsContract);
+    let client = custom_errors::CustomErrorsContractClient::new(&env, &id);
+
+    let err = client.try_validate_input(&0i64);
+    assert_eq!(err, Err(Ok(custom_errors::ContractError::InvalidInput)));
+}
+
+#[test]
+fn fuzz_custom_errors_one_accepted() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let id = env.register_contract(None, custom_errors::CustomErrorsContract);
+    let client = custom_errors::CustomErrorsContractClient::new(&env, &id);
+
+    let result = client.try_validate_input(&1i64);
+    assert!(result.is_ok());
+}
+
+// ---------------------------------------------------------------------------
+// Events counter — high increment count
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fuzz_events_high_increment_count() {
+    let env = Env::default();
+
+    let id = env.register_contract(None, events_structured::EventsContract);
+
+    for _ in 0..20 {
+        env.invoke_contract::<()>(&id, &symbol_short!("increment"), Vec::new(&env));
+    }
+
+    let count: u32 =
+        env.invoke_contract(&id, &Symbol::new(&env, "get_number"), Vec::new(&env));
+    assert_eq!(count, 20);
+}

--- a/tests/integration/tests/fuzz_tests.rs
+++ b/tests/integration/tests/fuzz_tests.rs
@@ -6,9 +6,7 @@
 #![cfg(not(target_arch = "wasm32"))]
 #![cfg(test)]
 
-use soroban_sdk::{
-    symbol_short, testutils::Address as _, Address, Env, IntoVal, Symbol, Vec,
-};
+use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env, IntoVal, Symbol, Vec};
 
 // ---------------------------------------------------------------------------
 // Storage — boundary values
@@ -361,7 +359,6 @@ fn fuzz_events_high_increment_count() {
         env.invoke_contract::<()>(&id, &symbol_short!("increment"), Vec::new(&env));
     }
 
-    let count: u32 =
-        env.invoke_contract(&id, &Symbol::new(&env, "get_number"), Vec::new(&env));
+    let count: u32 = env.invoke_contract(&id, &Symbol::new(&env, "get_number"), Vec::new(&env));
     assert_eq!(count, 20);
 }


### PR DESCRIPTION
## Summary

- **#608** — Restructured `book/src/SUMMARY.md` with distinct sections: Getting Started, Guides, Examples (by category), Use Cases, API Reference, Community, and Architecture Decisions. The previous flat \"Reference\" section is now clearly labelled \"API Reference\" and guides are split into their own top-level section with proper navigation.

- **#603** — Migrated core documentation content into `book/src/README.md`: project overview, quick start commands, full repository structure, examples tables (by difficulty and use case), guides index, and API reference index. The book introduction is now a standalone, complete reference that matches the root README.

- **#609** — Created `COMMUNITY_GUIDELINES.md` (root and `book/src/`) covering participation standards, code of conduct reinforcement, two reporting channels (GitHub and email), a four-level enforcement table, and prominent links from `CONTRIBUTING.md`. The document is wired into the mdBook navigation under a new \"Community\" section.

- **#602** — Added `tests/integration/tests/fuzz_tests.rs` with 13 boundary and edge-case tests across five basic example contracts: storage (max `u64`, zero, missing key, overwrite, temporary max), authentication (transfer full balance, many 1-unit transfers), error handling (minimum deposit, exact-boundary withdraw, consecutive deposits, overdraft rejection), custom errors (zero rejected, one accepted), and events counter (20 increments).

## Test plan

- [ ] `cd book && mdbook build` should succeed without config errors (all SUMMARY.md paths resolve to existing files)
- [ ] `cargo test -p integration-tests` should pass including the new `fuzz_tests` binary
- [ ] Verify `book/src/community-guidelines.md` renders in the built docs under the Community section
- [ ] Verify `CONTRIBUTING.md` prominently links to `COMMUNITY_GUIDELINES.md`

Closes #608
Closes #603
Closes #609
Closes #602