### PR TITLE
docs: add testing requirements section to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,3 +68,35 @@ Once you have worked through the onboarding guide and run `cargo test --workspac
 ---
 
 ## 🎯 Ways to Contribute
+
+## 🧪 Testing Requirements
+
+Every change that touches contract logic needs test coverage before it merges. This section covers the commands you need day-to-day; for testing patterns, fixtures, and best practices, see the [Testing Guide](./book/src/guides/testing.md) and [Testing Best Practices](./book/src/docs/testing-best-practices.md).
+
+### Running Tests
+
+```bash
+# Run everything in the workspace (what CI runs by default)
+cargo test --workspace
+
+# Run tests for a single example you're working on
+cd examples/<category>/<example-name>
+cargo test
+
+# Run the shared integration test suite
+cargo test -p integration-tests
+
+# Run the security-focused test suite
+cargo test --package security-tests
+```
+
+CI also runs `cargo fmt --all -- --check` and `cargo clippy --tests --lib -- -D warnings` — run both locally before opening a PR to avoid a red pipeline.
+
+### Where to Add a Test
+
+- **Example-level test** (`src/test.rs` or `tests/` inside the example crate): the default for any new or changed example. If the behavior only involves that one contract, it belongs here.
+- **Shared integration test** (`tests/integration/`): for scenarios that span multiple contracts — cross-contract calls, multi-step workflows, or state coordination between examples. See `tests/integration/README.md` for existing patterns before adding a new one.
+- **Security test** (`tests/security/`): for authorization bypass, reentrancy, and other security-relevant regressions. See `tests/security/README.md` for the threat models already covered.
+- **Fuzz target** (`tests/fuzz/`): for property-based testing of parsing/serialization boundaries. Only needed when you're adding a new fuzzable surface, not for typical example changes.
+
+Coverage is measured with `cargo tarpaulin` in CI and uploaded to Codecov; run `cargo tarpaulin` locally if you want to check coverage before pushing.


### PR DESCRIPTION
## Description

`CONTRIBUTING.md`'s table of contents links to a "Testing Requirements" section that didn't exist in the file. This adds it.

## Type of Change

- [x] Documentation update

## Changes Made

- Added a **🧪 Testing Requirements** section to `CONTRIBUTING.md` with:
  - The actual commands contributors need day-to-day: `cargo test --workspace`, per-example `cargo test`, `cargo test -p integration-tests`, `cargo test --package security-tests`, plus a reminder about the `fmt`/`clippy` checks CI runs.
  - A short decision guide for where a new test belongs: example-level (`src/test.rs`/`tests/` in the example crate) vs. shared integration (`tests/integration/`) vs. security (`tests/security/`) vs. fuzz (`tests/fuzz/`).
  - Links out to the existing [Testing Guide](book/src/guides/testing.md) and [Testing Best Practices](book/src/docs/testing-best-practices.md) docs for patterns/fixtures rather than duplicating that content.

Scoped to the testing section only — the other missing TOC sections in this file (Development Environment Setup, Code Style Guidelines, etc.) are a separate, larger gap outside this issue.

## Testing

Documentation-only change.

## Related

Phase 6 · Roadmap issue close #344 