### PR TITLE
docs: explain automatic search index rebuild on deploy

### DIFF
--- a/book/src/docs/search.md
+++ b/book/src/docs/search.md
@@ -99,3 +99,7 @@ To rebuild the search index after adding new content:
 ```bash
 cd book && mdbook build
 ```
+
+## Rebuild on Deploy
+
+You don't need to publish the rebuilt index yourself. The `Deploy Docs` GitHub Actions workflow (`.github/workflows/deploy-docs.yml`) runs `mdbook build` and pushes the output — including the freshly generated `searchindex.json` — to the `gh-pages` branch on every push to `main`. So once your content change merges, the live search index picks it up automatically on the next deploy; running `mdbook build` locally is only needed to preview your changes before opening a PR.


### PR DESCRIPTION
## Description

`book/src/docs/search.md` already documents the mdBook search feature thoroughly, but it was missing the one thing this roadmap item specifically asked for: an explanation of how the index gets rebuilt on deploy.

## Type of Change

- [x] Documentation update

## Changes Made

- Added a **Rebuild on Deploy** section to `book/src/docs/search.md` explaining that `.github/workflows/deploy-docs.yml` runs `mdbook build` and publishes the regenerated `searchindex.json` to `gh-pages` on every push to `main` — so contributors don't need to manually publish a rebuilt index, only run `mdbook build` locally to preview.

Kept this as a small, targeted addition since the rest of the search documentation already exists and is comprehensive.

## Testing

Documentation-only change.

## Related

Phase 5 · Roadmap issue #334