### PR TITLE
Add monthly community call governance templates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,10 +36,23 @@ We commit to:
 
 For more details, see the [Feedback System Documentation](docs/feedback-system/README.md).
 
+## Monthly Community Call Governance
+
+The Soroban Cookbook runs monthly community calls to share progress, demo examples, and answer questions. All call templates and governance documents are maintained in the [GOVERNANCE/](./GOVERNANCE/) directory:
+
+- [Agenda Template](./GOVERNANCE/monthly-call-agenda-template.md)
+- [Format Guidelines](./GOVERNANCE/monthly-call-format-guidelines.md)
+- [Moderation Guide](./GOVERNANCE/monthly-call-moderation-guide.md)
+- [Q&A Process](./GOVERNANCE/monthly-call-qa-process.md)
+- [Follow-up Process](./GOVERNANCE/monthly-call-followup-process.md)
+
+To propose a topic, moderate a session, or improve the process, open an issue or pull request in this repository.
+
 ---
 
 ## 📍 Table of Contents
 - [New Here? Start with Onboarding](#-new-here-start-with-onboarding)
+- [Monthly Community Call Governance](#monthly-community-call-governance)
 - [Ways to Contribute](#-ways-to-contribute)
 - [Development Environment Setup](#️-development-environment-setup)
 - [Code Style Guidelines](#-code-style-guidelines)

--- a/GOVERNANCE/README.md
+++ b/GOVERNANCE/README.md
@@ -1,0 +1,27 @@
+# Monthly Community Call Governance
+
+This directory contains the canonical templates and guides for running Soroban Cookbook monthly community calls.
+
+## Contents
+
+- [Agenda Template](./monthly-call-agenda-template.md)
+- [Format Guidelines](./monthly-call-format-guidelines.md)
+- [Moderation Guide](./monthly-call-moderation-guide.md)
+- [Q&A Process](./monthly-call-qa-process.md)
+- [Follow-up Process](./monthly-call-followup-process.md)
+
+## Purpose
+
+These documents ensure every community call is consistent, accessible, and productive. They are maintained by the core maintainer team and updated as the project evolves.
+
+## Usage
+
+1. Open the [Agenda Template](./monthly-call-agenda-template.md) at least 5 days before the call.
+2. Follow the [Format Guidelines](./monthly-call-format-guidelines.md) when configuring the call platform and promotion.
+3. Review the [Moderation Guide](./monthly-call-moderation-guide.md) before each session to set expectations.
+4. Use the [Q&A Process](./monthly-call-qa-process.md) to manage live questions.
+5. Execute the [Follow-up Process](./monthly-call-followup-process.md) within 48 hours of the call ending.
+
+## Feedback
+
+Propose changes or improvements by opening an issue or pull request in this repository.

--- a/GOVERNANCE/monthly-call-agenda-template.md
+++ b/GOVERNANCE/monthly-call-agenda-template.md
@@ -1,0 +1,72 @@
+# Monthly Call Agenda Template
+
+Use this template for every Soroban Cookbook monthly community call. Fill in the placeholders before the call and publish the agenda at least 5 days in advance so attendees can prepare questions.
+
+## Call Information
+
+| Field | Details |
+| ----- | ------- |
+| Date | YYYY-MM-DD |
+| Time | HH:MM UTC (list 1–2 additional time zones) |
+| Duration | 60 minutes |
+| Platform | [Link/Meeting ID] |
+| Calendar | [Link to Google Calendar / .ics] |
+| Recording | [Link or placeholder] |
+
+---
+
+## Agenda
+
+### 1. Welcome & Housekeeping (5 min)
+
+- Quick recap of last month's follow-up items
+- Code of Conduct reminder
+- Platform etiquette (mute, raise-hand, chat use)
+
+### 2. Project Updates (10 min)
+
+- Phase progress snapshot
+- Recent PR merges and releases
+- Upcoming milestones
+
+### 3. Feature Spotlight (15 min)
+
+- Topic / example
+- Presenter
+- Demo or walkthrough
+- Key discussion points
+
+### 4. Community Showcase (10 min)
+
+- New contributor shoutout
+- Feature requests or feedback from Discord / GitHub
+- Spotlight on external projects built with Soroban
+
+### 5. Open Discussion & Q&A (15 min)
+
+- Top-voted questions submitted in advance
+- Live chat and raise-hand queue
+- Action items captured in real time
+
+### 6. Closing & Next Steps (5 min)
+
+- Summary of decisions and action items
+- Announce next call date and theme
+- Prompt participants to submit feedback and topics for next month
+
+---
+
+## Pre-Call Checklist
+
+- [ ] Agenda published in GitHub Discussions and social channels
+- [ ] Recording link tested and permissions set
+- [ ] Moderator and co-host confirmed
+- [ ] Questions collected via GitHub Discussions / form
+- [ ] Follow-up document prepared
+
+## Post-Call Checklist
+
+- [ ] Recording uploaded and linked
+- [ ] Notes and action items published
+- [ ] Action items assigned to owners and due dates
+- [ ] Follow-up process initiated per [monthly-call-followup-process.md](./monthly-call-followup-process.md)

--- a/GOVERNANCE/monthly-call-followup-process.md
+++ b/GOVERNANCE/monthly-call-followup-process.md
@@ -1,0 +1,70 @@
+# Monthly Call Follow-up Process
+
+The follow-up process converts discussions from the monthly call into documented actions, recordings, and feedback for the next cycle.
+
+## Timeline
+
+| Deadline | Owner | Action |
+| -------- | ----- | ------ |
+| +24 hours | Note-taker | Publish raw notes to `GOVERNANCE/notes/YYYY-MM-notes.md` |
+| +48 hours | Host + Note-taker | Create follow-up entry in GitHub Discussions with recording, transcript, and action items |
+| +72 hours | Note-taker | Publish closed captions and final transcript link |
+| +7 days | Maintainer | Review action items and sync with GitHub Issues and project board |
+
+## Notes Template
+
+Copy and complete this template for every call:
+
+```markdown
+# Community Call Notes — YYYY-MM
+
+## Recording
+
+- Link: ...
+- Transcript: ...
+
+## Decisions
+
+- List any decisions made during the call.
+
+## Action Items
+
+| Action | Owner | Due Date | GitHub Issue / Status |
+|--------|-------|----------|----------------------|
+| ...    | ...   | ...      | #issue / open         |
+
+## Questions Carried Forward
+
+| Question | Owner | Due Date |
+|----------|-------|----------|
+| ...      | ...   | ...      |
+```
+
+## Action Item Handling
+
+- Each action item must have a single owner and a due date.
+- If no owner volunteers during the call, the host assigns it to a maintainer.
+- Duplicate or stale action items are merged into the existing issue before the next call.
+- Action items that are not resolved by the next call are reviewed in the follow-up process and either extended or closed with explanation.
+
+## Storage & Archive
+
+- Call notes, recordings, and transcripts are stored under `GOVERNANCE/notes/`.
+- The archive index is updated in [docs/README.md](../book/src/README.md) or linked from the community section.
+- Recordings older than 2 years that have no active references may be moved to cold storage, but links must remain valid.
+
+## Feedback Loop
+
+- After publishing the follow-up, prompt attendees to rate the call via a short form or GitHub Discussions thread.
+- Collect feedback on:
+  - Audio/video quality
+  - Agenda pacing
+  - Speaker content
+  - Q&A effectiveness
+- Review feedback at the start of the planning call for the next session.
+
+## Escalation
+
+- If an action item is blocked, the owner notifies the host within 48 hours.
+- The host escalates to the maintainer team during the weekly async sync.
+- If a participant feels an action item was missed or mishandled, they open a GitHub Issue tagged `community-followup`.

--- a/GOVERNANCE/monthly-call-format-guidelines.md
+++ b/GOVERNANCE/monthly-call-format-guidelines.md
@@ -1,0 +1,61 @@
+# Monthly Call Format Guidelines
+
+These guidelines define the standard format for Soroban Cookbook monthly community calls. Keeping a consistent format reduces friction, improves accessibility, and makes recordings easier to archive and reference.
+
+## Frequency & Scheduling
+
+- **Recurrence:** First Tuesday of every month.
+- **Time:** 16:00 UTC, adjusted seasonally if attendance data supports a better time.
+- **Duration:** 60 minutes, with a 5-minute buffer after for hallway chat.
+- **Calendar:** Publish at least 30 days in advance and update if the time or platform changes.
+
+## Platform Setup
+
+| Requirement | Standard | Notes |
+| ----------- | -------- | ----- |
+| Video platform | [Platform TBD] | Must support recording, closed captions, and breakout rooms. |
+| Audio standards | 16 kHz minimum | Recommend noise suppression and a dedicated broadcast channel for speakers. |
+| Closed captions | Live captions for entire call | Provide a volunteer captioner or auto-captions with human review. |
+| Chat / Q&A | Platform-native chat + GitHub Discussions | Dual-surface queue reduces lost questions. |
+| Registration | Optional RSVP | Collect timezone info and topics of interest as planning input. |
+
+## Recording & Accessibility
+
+- Record every call with both video and a separate audio track.
+- Add automated and reviewed closed captions within 48 hours.
+- Upload to the project's media host and link from [docs/community/archive].
+- Provide a transcript or timestamped outline alongside the video.
+- All materials must be licensed under the same open license as the repository.
+
+## Promotion Runway
+
+| Timing | Action |
+| ------ | ------ |
+| 14 days before | Draft commit with agenda and speaker line-up pushed to the repo |
+| 10 days before | Announce on Discord, X/Twitter, and GitHub Discussions |
+| 5 days before | Publish final agenda and collect questions |
+| 1 day before | Reminder post with direct join link |
+| Day of | Last-minute reminder 1 hour before the call |
+
+## Host Roles
+
+Every call needs three named roles:
+
+- **Host (1):** Opens the call, enforces the agenda, manages time.
+- **Co-host (1):** Manages platform features (mute, admit, queue), watches chat, raises flags.
+- **Note-taker (1):** Captures decisions, action items, and questions for the follow-up document.
+
+Rotate these roles among active contributors each month to share ownership of the call.
+
+## Accessibility Requirements
+
+- Provide agenda and slides at least 48 hours in advance.
+- Use high-contrast slides and readable fonts (minimum 24 pt).
+- Describe visual content verbally during demos.
+- Encourage speakers to identify themselves before speaking for the recording transcript.
+- Avoid flashing animations and provide content warnings for sensitive topics.
+
+## Cancellation Policy
+
+- If a speaker or host cancels within 72 hours, notify all RSVPs and reschedule immediately.
+- If the call cannot proceed, record a short video update and publish notes summarizing what would have been discussed.

--- a/GOVERNANCE/monthly-call-moderation-guide.md
+++ b/GOVERNANCE/monthly-call-moderation-guide.md
@@ -1,0 +1,66 @@
+# Monthly Call Moderation Guide
+
+This guide defines the moderation standards and escalation path for Soroban Cookbook community calls. It protects participants and keeps discussions focused and inclusive.
+
+## Code of Conduct Enforcement
+
+All calls are governed by the project [Code of Conduct](../CODE_OF_CONDUCT.md) and [Community Guidelines](../COMMUNITY_GUIDELINES.md). By joining, attendees agree to uphold these standards.
+
+## Moderation Roles
+
+| Role | Responsibilities |
+| ---- | ---------------- |
+| **Host** | Runs the agenda, assigns speakers, and keeps the call on time. |
+| **Co-host** | Monitors chat, admits attendees, removes disruptive participants, and flags incidents. |
+| **Note-taker** | Focuses on capturing questions and decisions; not a moderation role but should escalate anything they see in chat. |
+
+## Visible Expectations
+
+At the start of every call, the host should read or link to the following rules:
+
+1. Be respectful and constructive in chat and voice.
+2. Mute when not speaking.
+3. Use the raised-hand or queue feature for questions; avoid interrupting.
+4. No off-topic promotion or spam.
+5. Recording and captions will be published; keep this in mind when speaking.
+
+## Moderation Actions
+
+### Verbal Warning
+
+- Use for minor, first-time disruptions.
+- Example: "Please keep comments on topic and let the speaker finish."
+
+### Timeout / Mute
+
+- Use for repeated interruptions or off-topic chat spam.
+- Co-host mutes the participant or places them in a waiting room for the duration.
+
+### Removal from Call
+
+- Use for harassment, hate speech, or deliberate disruption.
+- Co-host removes the participant, notes the reason, and screenshots the chat if needed.
+- Do not publicly shame the participant during the call.
+
+### Post-Call Follow-Up
+
+Log incidents in a private moderation log maintained by maintainers. Align consequences with the severity table in [Community Guidelines](../COMMUNITY_GUIDELINES.md).
+
+## Handling Difficult Topics
+
+- If a discussion becomes heated, the host calls a 2-minute break.
+- After the break, the host pivots the conversation back to the agenda item.
+- If a topic is too controversial for the public channel, move it to a private breakout room or GitHub Discussions to continue offline.
+
+## Speaker Etiquette
+
+- Arrive 5 minutes early to test audio and screen share.
+- Keep spotlights and demos to the allocated time.
+- Pause regularly to allow questions and confirm understanding.
+- Avoid live coding without a fallback recording or slides prepared in advance.
+
+## Accessibility & Inclusion
+
+- Provide a chat-only path for participants who cannot speak.
+- Read aloud important chat messages so they appear in the recording transcript.
+- Allow people to submit questions in writing via GitHub Discussions or a shared document before or during the call.

--- a/GOVERNANCE/monthly-call-qa-process.md
+++ b/GOVERNANCE/monthly-call-qa-process.md
@@ -1,0 +1,54 @@
+# Monthly Call Q&A Process
+
+A fair, efficient Q&A process ensures every participant feels heard and productive discussions are not derailed by interruptions.
+
+## Question Collection Phases
+
+### Pre-Call Questions
+
+- **Deadline:** 48 hours before the call.
+- **Collection method:** GitHub Discussions thread titled "Monthly Call Questions — YYYY-MM".
+- **Format:** One question per comment; include the topic and context.
+- **Triage:** Host and note-taker upvote and label questions as `general`, `technical`, or `meta`.
+
+### Live Questions
+
+- Use the platform's raise-hand feature.
+- Chat questions are collected by the co-host and tagged with the speaker or topic.
+- The host reviews the queue between agenda segments and chooses the most relevant questions.
+
+### Off-Topic Questions
+
+- Redirect to GitHub Discussions, Discord, or a follow-up issue.
+- Announce during the call: "That's a great question—please continue the thread in Discussions so we can track it."
+
+## Running the Session
+
+1. Host reads the top-voted pre-call questions for each topic.
+2. After a speaker finishes, the host opens the floor for 2–3 live questions.
+3. If time runs short, the host moves remaining questions to the follow-up document.
+4. The note-taker records:
+   - The question summary
+   - The answer summary
+   - Any action item or owner
+
+## Queue Management Rules
+
+| Situation | Action |
+| --------- | ------ |
+| Participant dominates one round | "Let's take one more question so others can join, then we can continue in Discussions." |
+| Question is too broad or out of scope | Redirect to the appropriate channel and offer a 1-sentence summary if possible. |
+| Speaker does not know the answer | Commit to finding the answer after the call and add it to the follow-up document. |
+| Same question asked twice | Reference the original answer and move on. |
+
+## Language & Accessibility
+
+- Support English as the primary language; provide a chat-only channel if interpreters are available.
+- Allow participants to submit questions in writing via chat or a shared Google Doc if they cannot unmute.
+- Repeat questions in chat into the audio track so they appear in captions and transcripts.
+
+## Follow-Up
+
+- Unanswered questions are moved to the follow-up document with status `pending`.
+- The note-taker assigns each lingering question to a maintainer within 48 hours.
+- Maintainers reply in the GitHub Discussions thread or in the next call.

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -107,6 +107,12 @@
 - [Community Guidelines](./community-guidelines.md)
 - [How to Contribute](./CONTRIBUTING.md)
 - [Code of Conduct](./CODE_OF_CONDUCT.md)
+- [Monthly Call Governance](../GOVERNANCE/README.md)
+  - [Agenda Template](../GOVERNANCE/monthly-call-agenda-template.md)
+  - [Format Guidelines](../GOVERNANCE/monthly-call-format-guidelines.md)
+  - [Moderation Guide](../GOVERNANCE/monthly-call-moderation-guide.md)
+  - [Q&A Process](../GOVERNANCE/monthly-call-qa-process.md)
+  - [Follow-up Process](../GOVERNANCE/monthly-call-followup-process.md)
 
 # Architecture Decisions
 


### PR DESCRIPTION
## Summary

Adds a complete set of governance templates for Soroban Cookbook monthly community calls.

## Changes

- **Agenda Template** — Standardized 60-minute call structure with pre- and post-call checklists
- **Format Guidelines** — Recurrence schedule, platform standards, recording requirements, accessibility baseline, promotion runway, and cancellation policy
- **Moderation Guide** — Code of Conduct enforcement, role definitions (host/co-host/note-taker), visible expectations, moderation actions, speaker etiquette, and inclusion practices
- **Q&A Process** — Pre-call question collection, live queue management, language/accessibility accommodations, and follow-up assignment
- **Follow-up Process** — 48-hour notes publication, action-item tracking, archive storage, feedback loop, and escalation path

## References

- Closes #630
- Closes #632
- Closes #633
- Closes #634

## Verification

Manual verification against acceptance criteria:
- [x] Agenda template
- [x] Format guidelines
- [x] Moderation guide
- [x] Q&A process
- [x] Follow-up process