### PR TITLE
fix(ci): remaining wasm/test and clippy fixes

### DIFF
--- a/examples/advanced/06-gas-optimization/src/lib.rs
+++ b/examples/advanced/06-gas-optimization/src/lib.rs
@@ -1,24 +1,24 @@
 #![no_std]
 
+//! # Gas Optimization Patterns for Soroban
+//!
+//! This contract demonstrates 12 gas optimization techniques:
+//! 1. Storage tier selection (Instance vs Persistent vs Temporary)
+//! 2. Caching frequently accessed values
+//! 3. Batch operations vs individual operations
+//! 4. Symbol interning and short symbols
+//! 5. Using enums instead of strings for state
+//! 6. Minimizing storage reads per operation
+//! 7. Lazy initialization
+//! 8. Checked arithmetic vs unchecked
+//! 9. Short-circuit evaluation
+//! 10. Efficient error handling with typed errors
+//! 11. Bitflags for boolean state packing
+//! 12. Struct packing and layout optimization
+
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env, Symbol, Vec,
 };
-
-/// # Gas Optimization Patterns for Soroban
-///
-/// This contract demonstrates 12 gas optimization techniques:
-/// 1. Storage tier selection (Instance vs Persistent vs Temporary)
-/// 2. Caching frequently accessed values
-/// 3. Batch operations vs individual operations
-/// 4. Symbol interning and short symbols
-/// 5. Using enums instead of strings for state
-/// 6. Minimizing storage reads per operation
-/// 7. Lazy initialization
-/// 8. Checked arithmetic vs unchecked
-/// 9. Short-circuit evaluation
-/// 10. Efficient error handling with typed errors
-/// 11. Bitflags for boolean state packing
-/// 12. Struct packing and layout optimization
 
 /// DataKey enum for typed, efficient storage access.
 ///

--- a/examples/advanced/07-trusted-forwarder/src/lib.rs
+++ b/examples/advanced/07-trusted-forwarder/src/lib.rs
@@ -239,6 +239,9 @@ impl TrustedForwarder {
     }
 }
 
+// Demo recipient used by host tests. Gated off wasm so its `initialize` export
+// does not collide with TrustedForwarder (SDK 26 removed contractimpl export=false).
+#[cfg(any(test, not(target_family = "wasm")))]
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(u32)]
@@ -248,6 +251,7 @@ pub enum RecipientError {
     UnauthorizedCaller = 3,
 }
 
+#[cfg(any(test, not(target_family = "wasm")))]
 #[contracttype]
 pub enum RecipientDataKey {
     TrustedForwarder,
@@ -256,10 +260,12 @@ pub enum RecipientDataKey {
     LastSender,
 }
 
+#[cfg(any(test, not(target_family = "wasm")))]
 #[contract]
 pub struct SimpleRecipient;
 
-#[contractimpl(export = false)]
+#[cfg(any(test, not(target_family = "wasm")))]
+#[contractimpl]
 impl SimpleRecipient {
     pub fn initialize(env: Env, forwarder: Address) -> Result<(), RecipientError> {
         if env.storage().instance().has(&RecipientDataKey::Initialized) {

--- a/examples/advanced/07-upgrade-patterns/src/init_guard.rs
+++ b/examples/advanced/07-upgrade-patterns/src/init_guard.rs
@@ -153,6 +153,8 @@ impl InitGuardContract {
             return Err(InitError::AlreadyInitialized);
         }
 
+        admin.require_auth();
+
         // Write all initial state atomically (same transaction).
         env.storage().instance().set(&DataKey::Admin, &admin);
         // The flag is the source of truth — its *presence* is the guard.

--- a/examples/advanced/07-upgrade-patterns/src/lib.rs
+++ b/examples/advanced/07-upgrade-patterns/src/lib.rs
@@ -32,7 +32,12 @@
 #![allow(unexpected_cfgs)]
 
 pub mod direct_upgrade;
+
+// Each pattern module exports overlapping names (`initialize` / `upgrade` / `admin`).
+// Host tests need all three; wasm builds only the primary direct_upgrade example.
+#[cfg(any(test, not(target_family = "wasm")))]
 pub mod init_guard;
+#[cfg(any(test, not(target_family = "wasm")))]
 pub mod versioned_upgrade;
 
 #[cfg(test)]

--- a/examples/advanced/09-storage-layout-validator/src/test.rs
+++ b/examples/advanced/09-storage-layout-validator/src/test.rs
@@ -175,8 +175,10 @@ fn test_malformed_current_layout() {
     let current = layout(&env, 0, Vec::new(&env));
     let next = layout(&env, 1, Vec::new(&env));
 
-    let err = client.try_validate(&current, &next).unwrap().unwrap_err();
-    assert_eq!(err, Ok(LayoutError::MalformedLayout));
+    assert_eq!(
+        client.try_validate(&current, &next),
+        Err(Ok(LayoutError::MalformedLayout))
+    );
 }
 
 #[test]
@@ -186,8 +188,10 @@ fn test_malformed_next_layout() {
     let current = layout(&env, 1, Vec::new(&env));
     let next = layout(&env, 0, Vec::new(&env));
 
-    let err = client.try_validate(&current, &next).unwrap().unwrap_err();
-    assert_eq!(err, Ok(LayoutError::MalformedLayout));
+    assert_eq!(
+        client.try_validate(&current, &next),
+        Err(Ok(LayoutError::MalformedLayout))
+    );
 }
 
 #[test]

--- a/examples/basics/13-queue-variants/src/lib.rs
+++ b/examples/basics/13-queue-variants/src/lib.rs
@@ -122,10 +122,13 @@ impl BoundedQueueContract {
 }
 
 // Circular buffer ---------------------------------------------------------
+// Host/tests only: shares wasm export names with BoundedQueueContract.
 
+#[cfg(any(test, not(target_family = "wasm")))]
 #[contract]
 pub struct CircularBufferContract;
 
+#[cfg(any(test, not(target_family = "wasm")))]
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum CBKey {
@@ -133,6 +136,7 @@ pub enum CBKey {
     Element(i128),
 }
 
+#[cfg(any(test, not(target_family = "wasm")))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[contracttype]
 pub struct CBMeta {
@@ -142,6 +146,7 @@ pub struct CBMeta {
     pub len: i128,
 }
 
+#[cfg(any(test, not(target_family = "wasm")))]
 #[contractimpl]
 impl CircularBufferContract {
     pub fn initialize(env: Env, capacity: i128) {

--- a/examples/defi/06-flash-loan-use-cases/src/lib.rs
+++ b/examples/defi/06-flash-loan-use-cases/src/lib.rs
@@ -14,7 +14,12 @@
 #![no_std]
 
 pub mod arbitrage;
+
+// Secondary example contracts share export names (`init` / `execute` / `on_flash_loan`).
+// Keep them for host tests; omit from wasm so the cdylib has a single export set.
+#[cfg(any(test, not(target_family = "wasm")))]
 pub mod refinancing;
+#[cfg(any(test, not(target_family = "wasm")))]
 pub mod security;
 
 #[cfg(test)]

--- a/examples/defi/11-amm-price-oracle/src/lib.rs
+++ b/examples/defi/11-amm-price-oracle/src/lib.rs
@@ -266,7 +266,7 @@ impl AmmPoolContract {
 
 #[contractimpl]
 impl AmmOracleContract {
-    pub fn initialize(env: Env, owner: Address, pool_contract: Address) {
+    pub fn initialize_oracle(env: Env, owner: Address, pool_contract: Address) {
         if env.storage().instance().has(&OracleDataKey::Owner) {
             panic!("already initialized");
         }

--- a/examples/defi/11-amm-price-oracle/src/test.rs
+++ b/examples/defi/11-amm-price-oracle/src/test.rs
@@ -36,7 +36,7 @@ fn setup() -> (
 
     let oracle_id = env.register_contract(None, AmmOracleContract);
     let oracle_client = AmmOracleContractClient::new(&env, &oracle_id);
-    oracle_client.initialize(&owner, &pool_id);
+    oracle_client.initialize_oracle(&owner, &pool_id);
 
     (env, owner, alice, bob, pool_client, oracle_client, token_a_id, token_b_id)
 }

--- a/examples/intermediate/03-priority-queue/src/lib.rs
+++ b/examples/intermediate/03-priority-queue/src/lib.rs
@@ -1,6 +1,11 @@
 #![no_std]
 
-use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env, Symbol, Vec};
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env, Symbol, Vec,
+};
+
+const CONTRACT_NS: Symbol = symbol_short!("pqueue");
+const ACTION_HEAP: Symbol = symbol_short!("heap");
 
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]

--- a/examples/intermediate/03-priority-queue/src/test.rs
+++ b/examples/intermediate/03-priority-queue/src/test.rs
@@ -1,11 +1,10 @@
 use super::*;
 use soroban_sdk::{symbol_short, testutils::Address as _, vec, Address, Env, Symbol, Vec};
-use soroban_sdk::{symbol_short, Env};
 
 fn setup(env: &Env) -> (PriorityQueueContractClient<'_>, Address) {
     let contract_id = env.register(PriorityQueueContract, ());
     env.mock_all_auths();
-    let admin = Address::generate(&env);
+    let admin = Address::generate(env);
     let client = PriorityQueueContractClient::new(env, &contract_id);
     client.initialize(&admin);
     (client, admin)
@@ -45,7 +44,7 @@ fn test_len_and_is_empty_after_insertions() {
 #[test]
 fn test_heap_integrity_across_interleaved_pushes_and_pops() {
     let env = Env::default();
-    let client = setup(&env);
+    let (client, _) = setup(&env);
 
     let items = [
         (symbol_short!("a"), 4i128),

--- a/tests/integration/tests/advanced_integration_tests.rs
+++ b/tests/integration/tests/advanced_integration_tests.rs
@@ -21,7 +21,8 @@ fn test_version_registry_full_lifecycle() {
     let contract_addr = Address::generate(&env);
     let hash = BytesN::from_array(&env, &[0u8; 32]);
 
-    let _v1 = reg.register(&contract_addr, &hash, &symbol_short!("deploy"));
+    let v1 = reg.register(&contract_addr, &hash, &symbol_short!("deploy"));
+    assert_eq!(v1.timestamp, 1000);
     assert_eq!(reg.get_current_version_number(), 1);
 
     env.ledger().with_mut(|l| l.timestamp = 2000);

--- a/tests/integration/tests/advanced_integration_tests.rs
+++ b/tests/integration/tests/advanced_integration_tests.rs
@@ -274,7 +274,7 @@ fn test_storage_optimization_nonce_tracking() {
     let data1 = opt.get_user_data(&user);
     assert!(data1.nonce > 0);
 
-    opt.deposit(&user, &50);
+    opt.deposit(&user, &150);
     let data2 = opt.get_user_data(&user);
     assert!(data2.nonce > data1.nonce);
 }
@@ -318,8 +318,8 @@ fn test_storage_optimization_insufficient_balance() {
     opt.initialize(&admin);
 
     let user = Address::generate(&env);
-    opt.deposit(&user, &50);
-    let result = opt.try_withdraw(&user, &100);
+    opt.deposit(&user, &100);
+    let result = opt.try_withdraw(&user, &200);
     assert!(result.is_err());
 }
 

--- a/tests/integration/tests/defi_security_tests.rs
+++ b/tests/integration/tests/defi_security_tests.rs
@@ -126,10 +126,10 @@ fn test_prevent_reinitialization_amm_oracle() {
 
     let oracle_id = env.register_contract(None, AmmOracleContract);
     let oracle_client = AmmOracleContractClient::new(&env, &oracle_id);
-    oracle_client.initialize(&owner, &pool_id);
+    oracle_client.initialize_oracle(&owner, &pool_id);
 
     // Attempting second initialize must fail
-    oracle_client.initialize(&owner, &pool_id);
+    oracle_client.initialize_oracle(&owner, &pool_id);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
PR #867 merged the bulk of the CI-green work (`00d74ce2`), but three follow-up commits on `fix/ci-green` never landed on `main`. This PR carries those leftovers so wasm builds, tests, and clippy can go green.

### Commits not on main
- `8bfb35b` — resolve wasm export clashes and oracle/test API mismatches (flash-loan, upgrade-patterns, amm oracle rename, priority-queue, etc.)
- `25bd3f4` — use inner crate docs in gas-optimization (clippy / doc attribute fix)
- `7cc5dfc` — clear remaining wasm export clashes and integration deposits (CircularBuffer host gates, init_guard auth, storage-optimization min_deposit alignment)

### Notable areas
- Wasm multi-contract export gates (`cfg` / host vs contract boundaries)
- Flash-loan and upgrade-patterns contract surface fixes
- AMM price-oracle rename alignment in lib + tests
- Gas-optimization docs / clippy
- Integration test deposit / auth alignment

## Test plan
- [ ] CI: Build Contracts passes
- [ ] CI: Clippy Lint passes
- [ ] CI: Test Suite passes
- [ ] CI: Code Coverage job healthy (or non-blocking as configured)


Made with [Cursor](https://cursor.com)