### PR TITLE
fix(pausable-token): capture transfer events before balance reads

### DIFF
--- a/examples/tokens/03-pausable-token/src/test.rs
+++ b/examples/tokens/03-pausable-token/src/test.rs
@@ -57,11 +57,12 @@ fn transfer_works_when_unpaused() {
 
     f.token.transfer(&f.admin, &f.alice, &500_000);
 
-    assert_eq!(f.token.balance(&f.admin), 500_000);
-    assert_eq!(f.token.balance(&f.alice), 500_000);
-
+    // `events().all()` only covers the last successful invocation.
     let events = EventList::new(&f.env, f.env.events().all());
     assert_eq!(events.len(), 1);
+
+    assert_eq!(f.token.balance(&f.admin), 500_000);
+    assert_eq!(f.token.balance(&f.alice), 500_000);
 
     let (_id, topics, data) = events.get(0).unwrap();
     assert_eq!(topics.len(), 4);


### PR DESCRIPTION
## Summary
- Fixes `transfer_works_when_unpaused` failing on main after #868 (`assert left=0 right=1` on event count).
- Under SDK 26, `env.events().all()` only returns events from the **last** successful contract invocation. The test called `balance` before reading events, so the transfer event was gone.
- Capture events immediately after `transfer`, then assert balances.

## Test plan
- [x] `cargo test -p pausable-token --lib --target x86_64-unknown-linux-gnu` (24 passed)
- [x] `cargo test -p security-tests -p integration-tests --target x86_64-unknown-linux-gnu`


Made with [Cursor](https://cursor.com)